### PR TITLE
Document phase 0 completion and seed phase 1 research

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,16 @@ Hiero introduces modular network layers, virtualization of consensus participati
    * [`docs/references/bibliography.md`](docs/references/bibliography.md) for canonical sources.
    * [`docs/decisions/log.md`](docs/decisions/log.md) to understand accepted modelling choices.
    * [`docs/tooling/toolchain.md`](docs/tooling/toolchain.md) for ROBOT/Codex setup guidance.
-3. **Set up tooling:**
+3. **Review Phase 1 research outputs:**
+   * [`docs/inventory/content-audit.md`](docs/inventory/content-audit.md) for glossary candidates and modelling hooks.
+   * [`docs/inventory/context-maps.md`](docs/inventory/context-maps.md) for draft actor/service relationship diagrams.
+   * [`docs/competency/backlog.md`](docs/competency/backlog.md) for high-priority competency questions.
+   * [`docs/research/ontology-landscape.md`](docs/research/ontology-landscape.md) for external vocabulary alignment notes.
+4. **Set up tooling:**
    * Install [Protégé](https://protege.stanford.edu/) for authoring OWL axioms.
    * Install [ROBOT](https://robot.obolibrary.org/) with Java 11+ for automation; optional Python environment with [`rdflib`](https://rdflib.readthedocs.io/), [`pyshacl`](https://github.com/RDFLib/pySHACL), and [`owlready2`](https://owlready2.readthedocs.io/).
-4. **Collect source materials:** maintain and extend the shared bibliography of Hedera, Hiero, HIP, and mirror node references under `docs/references/`.
-5. **Model & validate:** start with the seed module defined in the workplan (accounts & governance), ensuring each class/property is backed by documentation quotes and competency questions.
+5. **Collect source materials:** maintain and extend the shared bibliography of Hedera, Hiero, HIP, and mirror node references under `docs/references/`.
+6. **Model & validate:** start with the seed module defined in the workplan (accounts & governance), ensuring each class/property is backed by documentation quotes and competency questions.
 
 ## Contributing
 

--- a/docs/competency/backlog.md
+++ b/docs/competency/backlog.md
@@ -1,0 +1,28 @@
+# Phase 1 Competency Question Backlog
+
+This backlog captures high-priority competency questions (CQs) that will guide ontology modelling, SHACL validation, and SPARQL query development.  Each entry references the stakeholder motivation, expected data sources, and relevant documentation anchors.
+
+## How to use this backlog
+
+1. Reference IDs in issues, ontology modules, and SHACL shapes so traceability is preserved.
+2. Update the **Status** column as questions move from draft to validated (via SPARQL or SHACL evidence).
+3. Link answers or query artefacts once produced to accelerate regression testing.
+
+| ID | Stakeholder | Priority | Question | Source(s) | Notes | Status |
+| -- | ----------- | -------- | -------- | --------- | ----- | ------ |
+| CQ-GOV-001 | Governance | High | Which Hedera Council members currently steward validator onboarding decisions and what HIPs underpin their mandates? | [Hedera Council](https://hedera.com/council); [HIP-840](https://hips.hedera.com/hip/hip-840) | Requires modelling council committees, meeting records, and HIP provenance. | Draft |
+| CQ-GOV-002 | Governance | High | What quorum of council votes authorised the latest network fee schedule update? | [Council governance](https://hedera.com/council); [Fee schedule docs](https://docs.hedera.com/hedera/core-concepts/fees) | Dependent on availability of public vote records or release notes. | Draft |
+| CQ-COMP-003 | Compliance | High | Which tokens classified as stablecoins (HIP-540) enforce KYC and freeze keys, and who controls those keys? | [HIP-540](https://hips.hedera.com/hip/hip-540); [Token Service](https://docs.hedera.com/hedera/sdks-and-apis/token-service/introduction) | Drives modelling of token compliance attributes and account roles. | Draft |
+| CQ-COMP-004 | Compliance | Medium | Which scheduled transactions remain pending beyond 24 hours due to missing signatures? | [Scheduled transactions](https://docs.hedera.com/hedera/core-concepts/scheduled-transactions); [Mirror REST schedules](https://docs.hedera.com/hedera/mirror-node/sdks-and-apis/rest-api#tag/Schedule) | Requires temporal reasoning and mirror data ingestion. | Draft |
+| CQ-DEV-005 | Developer tooling | High | Which smart contracts invoke HTS system contract precompiles and what gas usage patterns do they exhibit? | [HSCS system contracts](https://docs.hedera.com/hedera/core-concepts/smart-contracts/system-contracts); [Mirror contract logs](https://docs.hedera.com/hedera/mirror-node/sdks-and-apis/rest-api#tag/Contracts) | Supports optimisation guidance and ontology alignment with execution traces. | Draft |
+| CQ-DEV-006 | Developer tooling | Medium | Which topics enforce both admin and submit key signatures for configuration updates? | [HCS configuration](https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/manage-topics); [Mirror topics endpoint](https://docs.hedera.com/hedera/mirror-node/sdks-and-apis/rest-api#tag/Topics) | Connects governance metadata with operational artefacts. | Draft |
+| CQ-ANL-007 | Analytics | High | How is total supply of fungible tokens distributed across treasury and external accounts over time? | [Token Service](https://docs.hedera.com/hedera/sdks-and-apis/token-service/token-relationships); [Mirror balances](https://docs.hedera.com/hedera/mirror-node/sdks-and-apis/rest-api#tag/Balances) | Requires longitudinal aggregation and PROV links to mirror exports. | Draft |
+| CQ-ANL-008 | Analytics | Medium | Which consensus topics have retention periods shorter than 30 days and which dApps depend on them? | [HCS retention](https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-retention); [Mirror subscriptions](https://docs.hedera.com/hedera/mirror-node/sdks-and-apis/topics) | Encourages modelling of topic consumers and SLAs. | Draft |
+| CQ-HIE-009 | Hiero transition | High | Which validators are participating in each Hiero shard and what onboarding state (pending, active, slashed) do they occupy? | [HIP-840](https://hips.hedera.com/hip/hip-840); [Hiero docs](https://docs.hedera.com/hiero) | Depends on forthcoming public datasets; placeholder for future integration. | Draft |
+| CQ-HIE-010 | Hiero transition | Medium | How do shard-level consensus finality times compare to mainnet benchmarks for a given epoch? | [Hiero docs](https://docs.hedera.com/hiero); [Mirror performance metrics](https://docs.hedera.com/hedera/mirror-node/architecture/metrics) | Will require time-series data capture and modelling of performance indicators. | Draft |
+
+## Next actions
+
+* Prioritise CQ-GOV-001, CQ-COMP-003, and CQ-DEV-005 for initial ontology modelling, as they cover governance, compliance, and developer tooling focal areas.
+* Identify authoritative data sources (council minutes, HIP releases, mirror node datasets) to ground each question before drafting SPARQL queries.
+* Add lower-priority questions (e.g., education, ecosystem tooling) once foundational modules stabilise.

--- a/docs/inventory/content-audit.md
+++ b/docs/inventory/content-audit.md
@@ -1,0 +1,106 @@
+# Phase 1 Content Audit
+
+This document captures candidate glossary entries and modelling hooks extracted from Hedera and Hiero documentation.  The audit focuses on concepts that recur across manuals, HIPs, and API references so that subsequent ontology classes can be justified with citations.
+
+## Methodology
+
+1. Prioritise canonical sources enumerated in the shared [bibliography](../references/bibliography.md).
+2. Capture the Hedera/Hiero term, a concise ontological description, and the documentation anchor for traceability.
+3. Note modelling considerations (e.g., required properties, lifecycle events, alignment opportunities) to inform competency questions and SHACL shapes.
+4. Flag follow-up research when documentation gaps or ambiguities appear.
+
+## Service and domain glossary candidates
+
+### Consensus Service (HCS)
+
+| Concept | Description | Source | Notes |
+| ------- | ----------- | ------ | ----- |
+| Topic | Ordered message channel configured with admin/submit keys, access controls, and message retention settings. | [Hedera Consensus Service](https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service) | Model as core artefact with governance on topic creation, key rotation, and deletion. |
+| SubmitMessage transaction | Transaction that appends messages to a topic with optional chunking, memo, and submit key signature requirements. | [HCS Submit message flow](https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/publish-and-subscribe) | Requires provenance links between submitting account, topic, and resulting message event. |
+| Topic message | Immutable payload recorded with consensus timestamp and sequence number, optionally mirrored via REST/gRPC. | [Mirror node message reference](https://docs.hedera.com/hedera/mirror-node/sdks-and-apis/topics) | Capture linkage to mirror exports and retention policies. |
+| Topic retention policy | Configuration for how long messages remain queryable (per topic or network default). | [HCS retention docs](https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-retention) | Influences temporal reasoning and data availability constraints. |
+
+### Token Service (HTS)
+
+| Concept | Description | Source | Notes |
+| ------- | ----------- | ------ | ----- |
+| Fungible token | Token type with divisible supply, treasury account, and configurable supply keys/custom fees. | [Token Service overview](https://docs.hedera.com/hedera/sdks-and-apis/token-service/introduction) | Capture supply control properties and relationships to treasury accounts. |
+| Non-fungible token (NFT) | Unique token instances with serial numbers, metadata, and HIP-412 compliance requirements. | [HIP-412 NFT standard](https://hips.hedera.com/hip/hip-412) | Model mint/burn lifecycle events and metadata schema constraints. |
+| Token relationship | Per-account state tracking KYC, freeze, balance, and allowance settings for a specific token. | [Token relationship docs](https://docs.hedera.com/hedera/sdks-and-apis/token-service/token-relationships) | Requires SHACL constraints for allowed state combinations. |
+| Custom fee (royalty/fixed) | Fee assessed during token transfers (e.g., HIP-423 royalties, fixed fees). | [HIP-423 Royalties](https://hips.hedera.com/hip/hip-423) | Represent as policy artefact referencing collector accounts and calculation formulas. |
+
+### Smart Contract Service (HSCS)
+
+| Concept | Description | Source | Notes |
+| ------- | ----------- | ------ | ----- |
+| Smart contract | Deployed EVM bytecode executed on Hedera with contract ID, linked admin keys, and gas usage. | [Smart contract overview](https://docs.hedera.com/hedera/core-concepts/smart-contracts) | Align with `prov:Activity` for executions and capture state linkage to file storage. |
+| Contract bytecode file | File Service artefact storing the compiled contract bytecode prior to deployment. | [Contract deployment flow](https://docs.hedera.com/hedera/sdks-and-apis/smart-contracts/deploy-contracts) | Bridge HSCS with File Service; track provenance to source artefacts. |
+| System contract | Hedera-provided precompiled contract that exposes native services (e.g., HTS precompiles). | [System contract reference](https://docs.hedera.com/hedera/core-concepts/smart-contracts/system-contracts) | Represent as managed artefacts with versioning tied to network releases. |
+| Gas & fee schedule | Cost model for contract execution, measured in gas and convertible to hbar fees. | [Smart contract fees](https://docs.hedera.com/hedera/core-concepts/smart-contracts/gas-and-fees) | Link to network fee schedules and staking rewards accounting. |
+
+### File Service
+
+| Concept | Description | Source | Notes |
+| ------- | ----------- | ------ | ----- |
+| File object | Storage container for bytecode, configuration, or metadata with size limits and expiration. | [File Service concepts](https://docs.hedera.com/hedera/core-concepts/file-service) | Associate with checksum, content type, and governance on mutability. |
+| File keys | Key list controlling file updates, deletion, and access. | [File permissions](https://docs.hedera.com/hedera/core-concepts/file-service/file-permissions) | Model as key relationships reused by contracts and topics. |
+| File expiration & auto-renew | Lifecycle management specifying expiration timestamps and auto-renew accounts. | [File lifecycle](https://docs.hedera.com/hedera/core-concepts/file-service/file-lifecycle) | Important for retention policies and dependency tracking. |
+
+### Scheduled Transactions
+
+| Concept | Description | Source | Notes |
+| ------- | ----------- | ------ | ----- |
+| Schedule entity | Wrapper storing a future transaction, its payer, and execution conditions. | [Scheduled transactions overview](https://docs.hedera.com/hedera/core-concepts/scheduled-transactions) | Map to underlying transaction types and required signatures. |
+| Scheduled signature | Individual signature contributions tracked toward execution thresholds. | [Scheduled signing flow](https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/sign-a-scheduled-transaction) | Requires modelling of signer roles and expiration windows. |
+| Execution window | Period before the schedule expires or is executed once signatures are collected. | [Schedule execution semantics](https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/execute-a-scheduled-transaction) | Enables temporal reasoning about pending obligations. |
+
+### Staking & Network Participation
+
+| Concept | Description | Source | Notes |
+| ------- | ----------- | ------ | ----- |
+| Staking node | Consensus node with staking parameters, node ID, and stake weight. | [Staking overview](https://docs.hedera.com/hedera/core-concepts/staking) | Links to validator operators and reward calculation. |
+| Staking reward period | Epoch in which rewards accrue and are distributed to staked accounts. | [Reward period docs](https://docs.hedera.com/hedera/core-concepts/staking/rewards) | Drives temporal events and payout provenance. |
+| Staking metadata account | Account storing metadata about staking preferences (decline rewards, auto-stake). | [Stake account settings](https://docs.hedera.com/hedera/core-concepts/staking/stake-your-account) | Connects to governance rules and scheduled payouts. |
+
+### Mirror Nodes & Data Exports
+
+| Concept | Description | Source | Notes |
+| ------- | ----------- | ------ | ----- |
+| Mirror node | Off-ledger service replicating consensus data via REST/gRPC APIs. | [Mirror node overview](https://docs.hedera.com/hedera/mirror-node) | Distinguish community vs managed nodes and deployment topology. |
+| REST API dataset | Resources exposing transactions, balances, topics, tokens, contracts, etc. | [Mirror node REST reference](https://docs.hedera.com/hedera/mirror-node/sdks-and-apis/rest-api) | Map to DCAT dataset vocabulary for catalogue alignment. |
+| Record file stream | Consensus record export (protobuf) consumed by analytics tooling. | [Record file format](https://docs.hedera.com/hedera/mirror-node/architecture/record-and-balance-files) | Supports provenance modelling for downstream data products. |
+
+### Governance & Actors
+
+| Concept | Description | Source | Notes |
+| ------- | ----------- | ------ | ----- |
+| Hedera Council | Governing body overseeing network policy, membership, and upgrades. | [Hedera Council](https://hedera.com/council) | Represent membership, voting rules, and decision provenance. |
+| Network node operator | Organisation operating consensus or mirror nodes under council agreements. | [Node operator program](https://hedera.com/council/members) | Capture contractual roles and compliance obligations. |
+| Account key hierarchy | Multi-key structures (threshold, key lists) controlling accounts and services. | [Account keys](https://docs.hedera.com/hedera/core-concepts/accounts/keys) | Foundational for modelling permissions across services. |
+
+### Hiero architecture extensions
+
+| Concept | Description | Source | Notes |
+| ------- | ----------- | ------ | ----- |
+| Shard | Partition of the network providing consensus scalability in Hiero. | [HIP-840 Hiero network](https://hips.hedera.com/hip/hip-840) | Model as `hedera:NetworkSegment` linked to validators and services. |
+| Consensus layer | Hiero module responsible for ordering transactions and managing validator sets. | [Hiero docs](https://docs.hedera.com/hiero) | Align with base `hedera:Service` hierarchy. |
+| Execution layer | Layer handling transaction execution, smart contract processing, and state storage. | [Hiero architecture overview](https://docs.hedera.com/hiero) | Capture dependencies on consensus layer outputs and state commitments. |
+| Validator role (permissionless) | Expanded node role enabling community participation with staking and slashing rules. | [HIP-840 Hiero network](https://hips.hedera.com/hip/hip-840) | Model onboarding workflows and compatibility with existing governance. |
+
+## Cross-cutting observations
+
+* Many artefacts (topics, tokens, contracts, schedules) share governance patterns involving admin/submit keys; modelling reusable permission structures will reduce duplication.
+* Lifecycle events (creation, update, expiry, deletion) should be represented consistently—likely via `prov:Activity` specialisations referencing network timestamps and mirror exports.
+* Mirror node datasets provide verifiable evidence for competency question validation; align them with DCAT and PROV to trace raw to processed data products.
+
+## Open research questions
+
+1. How should topic/message retention policies map to SHACL constraints for data consumers with partial history requirements?
+2. What minimal metadata is required to represent Hiero shard topology and validator capabilities without speculative assumptions?
+3. Which governance artefacts (council votes, HIP ratification steps) have structured data sources suitable for automation?
+
+## Next steps
+
+* Prioritise glossary items with high ontology impact (tokens, accounts, staking) for detailed definition drafts in Protégé.
+* Coordinate with competency question authors to ensure each item has at least one motivating query in the [backlog](../competency/backlog.md).
+* Augment this audit with direct quotations or paraphrased definitions during ontology authoring to maintain traceability.

--- a/docs/inventory/context-maps.md
+++ b/docs/inventory/context-maps.md
@@ -1,0 +1,78 @@
+# Hedera & Hiero Context Maps (Phase 1 Draft)
+
+These draft context diagrams capture how major actors, services, and artefacts interact across the Hedera network and forthcoming Hiero architecture.  They will evolve alongside formal ontology modelling and visual assets (e.g., draw.io, Excalidraw) in subsequent iterations.
+
+## Actor-to-service relationships
+
+```mermaid
+graph TD
+  Council[Hedera Council] -->|Appoints| NodeOperator[Consensus Node Operator]
+  Council -->|Ratifies| HIP[HIP Standards]
+  NodeOperator -->|Runs| ConsensusService[Consensus Service]
+  NodeOperator -->|Runs| MirrorNode[Mirror Node]
+  Wallet[Wallet / dApp] -->|Submits| Transactions
+  Transactions -->|Invoke| ConsensusService
+  Transactions -->|Invoke| TokenService[Token Service]
+  Transactions -->|Invoke| SmartContractService[Smart Contract Service]
+  SmartContractService -->|Persists bytecode| FileService[File Service]
+  ScheduledTxn[Scheduled Transaction] -->|Triggers| Transactions
+  MirrorNode -->|Publishes| DataExports[REST/gRPC Data Exports]
+  Analytics[Analytics / Compliance] -->|Consumes| DataExports
+```
+
+**Observations**
+
+* Wallets and dApps interact with multiple services through the same transaction pipeline; modelling a shared `hedera:Transaction` backbone is essential.
+* The council influences both governance artefacts (HIPs) and operational actors (node operators), reinforcing the need for provenance links between policy and implementation.
+* Mirror nodes act as the bridge between on-ledger events and off-ledger analytics, warranting DCAT/PROV alignments.
+
+## Hiero modular layering
+
+```mermaid
+graph TD
+  subgraph Hiero
+    ConsensusLayer[Consensus Layer]
+    ExecutionLayer[Execution Layer]
+    ServiceLayer[Service Layer]
+  end
+  ConsensusLayer -->|Finalizes| ShardLedger[Shard Ledgers]
+  ExecutionLayer -->|Applies| Transactions
+  ServiceLayer -->|Hosts| DomainServices[HTS / HSCS / File]
+  Validator[Permissionless Validator] -->|Participates| ConsensusLayer
+  Validator -->|Executes| ExecutionLayer
+  GovernancePortal[Validator Onboarding] -->|Manages| Validator
+  ShardLedger --> MirrorExports[Mirror Export Pipelines]
+```
+
+**Observations**
+
+* Hiero introduces explicit layering that separates consensus from execution; ontology modules should encode these as subclasses of `hedera:Service` with dependencies.
+* Permissionless validators participate in both consensus and execution flows, requiring role modelling that extends existing node operator concepts.
+* Shard-specific ledgers will influence how mirror exports and analytics partition data; competency questions should account for shard context.
+
+## Data lifecycle overview
+
+```mermaid
+graph LR
+  UserEvent[User / dApp Action]
+  UserEvent --> TransactionSubmission[Transaction Submission]
+  TransactionSubmission --> ConsensusOrdering[Consensus Ordering]
+  ConsensusOrdering --> ExecutionPhase[Service Execution]
+  ExecutionPhase --> RecordFiles[Record & Balance Files]
+  RecordFiles --> MirrorAPIs[Mirror APIs]
+  MirrorAPIs --> AnalyticsPipelines[Analytics & Compliance Pipelines]
+  AnalyticsPipelines --> Feedback[Governance Feedback / HIP Proposals]
+  Feedback --> Council
+```
+
+**Observations**
+
+* Every lifecycle stage has observable artefacts (transactions, record files, mirror API payloads) suitable for provenance modelling.
+* Feedback loops from analytics/compliance back to governance suggest competency questions around policy effectiveness and anomaly detection.
+* Staking reward calculations intersect with both execution outputs and governance oversight—capture this interplay in later diagrams.
+
+## Next steps
+
+1. Validate these draft diagrams with subject matter experts and replace with high-fidelity visuals once relationships stabilise.
+2. Align Mermaid elements with forthcoming ontology class names to keep documentation and OWL modules in sync.
+3. Extend the diagrams to include scheduled transactions, staking reward cycles, and cross-shard messaging once Hiero specifications mature.

--- a/docs/research/ontology-landscape.md
+++ b/docs/research/ontology-landscape.md
@@ -1,0 +1,58 @@
+# External Ontology Landscape Review (Phase 1)
+
+Phase 1 requires identifying reusable vocabularies that can accelerate Bhash modelling.  This review surveys candidate ontologies and patterns, highlighting immediate reuse opportunities and follow-up actions.
+
+## Summary matrix
+
+| Ontology / Pattern | Domain coverage | Reuse opportunities | Considerations |
+| ------------------ | --------------- | ------------------- | --------------- |
+| [PROV-O](https://www.w3.org/TR/prov-o/) | Provenance of activities, agents, and entities. | Transaction lifecycle, governance decisions, mirror export derivations. | Determine profiling for consensus vs execution activities. |
+| [DCAT 3](https://www.w3.org/TR/vocab-dcat-3/) | Dataset cataloguing. | Mirror node REST/gRPC datasets, record/balance file descriptions. | Extend with Hedera-specific distribution metadata (e.g., network, retention). |
+| [DID Core](https://www.w3.org/TR/did-core/) | Decentralised identifier representation. | Accounts, keys, and wallet bindings. | Assess compatibility with Hedera account ID format and key rotation semantics. |
+| [FIBO](https://spec.edmcouncil.org/fibo/) | Financial instruments & governance. | Token classifications, treasury roles, governance committees. | Scope alignment needed; avoid over-constraining token semantics. |
+| [ODRL](https://www.w3.org/TR/odrl-model/) | Policy/permission modelling. | Custom fee rules, access control statements for topics/files. | Evaluate complexity relative to simpler policy shapes. |
+| [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/) | Telemetry schema for observability. | Potential mapping for node metrics and mirror observability data. | Likely optional until telemetry integration is prioritised. |
+
+## Detailed notes
+
+### PROV-O
+
+* Map Hedera transactions to `prov:Activity` instances with associated `prov:Agent` roles (payer, operator, validator).
+* Represent mirror node exports as `prov:Entity` derived from record files, enabling traceability for analytics pipelines.
+* Next step: design a minimal PROV profile capturing transaction submission, consensus finalisation, execution, and export.
+
+### DCAT 3
+
+* Use `dcat:Dataset` for mirror REST/gRPC datasets (transactions, balances, topics) and `dcat:Distribution` for endpoint-specific metadata.
+* Capture shard or network scope via `dcat:spatial` or custom properties referencing Hiero shards.
+* Next step: draft a template for dataset metadata referencing the [Mirror node REST API](https://docs.hedera.com/hedera/mirror-node/sdks-and-apis/rest-api).
+
+### DID Core
+
+* Hedera accounts and keys can be modelled as DID subjects with verification methods referencing ED25519/threshold key material.
+* Wallet integrations can express account custody and key rotation via DID Document updates.
+* Next step: evaluate whether Hedera's `0.0.x` account identifiers should appear as DID methods (e.g., `did:hedera:`) or remain separate identifiers.
+
+### FIBO
+
+* Provides rich financial governance and organisational vocabulary for council committees, token categories (stablecoin, asset-backed), and compliance roles.
+* Complex ontology; consider importing only relevant modules (e.g., `FND`, `IND`, `BUs`) to avoid reasoning overhead.
+* Next step: create a mapping table for token and governance terms against FIBO classes referenced in the [Token Service documentation](https://docs.hedera.com/hedera/sdks-and-apis/token-service/introduction).
+
+### ODRL
+
+* Offers policy expressions that can model token custom fees (constraints, duties, permissions) and file/topic access control statements.
+* Might be heavyweight for early phases; consider SHACL-based policy shapes first.
+* Next step: prototype an ODRL policy capturing an HTS royalty rule defined in [HIP-423](https://hips.hedera.com/hip/hip-423).
+
+### OpenTelemetry semantic conventions
+
+* Relevant for future monitoring use cases (node metrics, mirror API performance) mentioned in [Hedera mirror node metrics docs](https://docs.hedera.com/hedera/mirror-node/architecture/metrics).
+* Could align Hiero observability artefacts with standard telemetry terms.
+* Next step: catalogue which metrics are publicly exposed to gauge scope.
+
+## Action items
+
+1. Draft minimal import profiles for PROV-O and DCAT to include in the core ontology module.
+2. Schedule deeper evaluation sessions for DID Core and FIBO once account/governance modelling begins.
+3. Track experimental ODRL/telemetry alignments as optional extensions until concrete competency questions demand them.

--- a/docs/workplan.md
+++ b/docs/workplan.md
@@ -20,12 +20,22 @@ This workplan outlines the research, modelling, validation, and delivery activit
 | Toolchain | Decide on preferred tooling (Protégé, ROBOT, rdflib notebooks) and document setup scripts. | [`tooling/toolchain.md`](tooling/toolchain.md) documents Codex + ROBOT workflow and installation steps. |
 
 
+### Phase 0 completion review (2024-05-02)
+
+* ✅ Bibliography seeded with canonical Hedera and Hiero sources as captured in [`docs/references/bibliography.md`](references/bibliography.md).
+* ✅ Governance and decision tracking process established via [`docs/decisions/log.md`](decisions/log.md), including tooling adoption records.
+* ✅ Preferred research and automation toolchain documented in [`docs/tooling/toolchain.md`](tooling/toolchain.md) with actionable installation guidance.
+* 🎯 Exit criteria met: documentation foundations are in place, enabling transition into the Phase 1 domain inventory tasks below.
+
+
 ## Phase 1 – Domain inventory (Weeks 1-2)
 
 1. **Content audit:** Extract glossary candidates and process descriptions from Hedera docs (HCS, HTS, HSCS, File Service, Scheduled Transactions, Staking, Mirror Nodes, Token Service standards) and Hiero architectural posts.
 2. **Context diagrams:** Draft context maps showing relationships between actors (council, node operators, wallets, dApps), services, and artefacts.
 3. **Competency question backlog:** Capture high-priority queries grouped by stakeholder (governance, compliance, developer tooling, analytics).
 4. **Existing ontology review:** Identify reusable patterns (e.g., ODRL for permissions, FIBO for financial instruments, IETF DID for identifiers).
+
+_Current artefacts (2024-05-02):_ [`content-audit`](inventory/content-audit.md), [`context-maps`](inventory/context-maps.md), [`competency backlog`](competency/backlog.md), and [`ontology landscape review`](research/ontology-landscape.md).
 
 ## Phase 2 – Core ontology foundation (Weeks 3-4)
 


### PR DESCRIPTION
## Summary
- mark Phase 0 deliverables as complete in the workplan and record transition guidance for Phase 1
- add initial Phase 1 artefacts covering content audit tables, context maps, competency question backlog, and external ontology review
- update the README to point contributors at the new research documentation

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68c93aa0c38c8323a48ddf8ea7785b4b