### PR TITLE
Add script for installing ROBOT CLI

### DIFF
--- a/docs/tooling/toolchain.md
+++ b/docs/tooling/toolchain.md
@@ -26,7 +26,7 @@ RDFlib remains useful for Python-based data wrangling, but ROBOT's ontology-spec
 ## Installation & environment
 
 1. **Java runtime** – install OpenJDK 11 or 17.
-2. **ROBOT** – download the latest release or install via package manager.
+2. **ROBOT** – download the latest release, install via package manager, or run the repository bootstrap script.
    ```bash
    # macOS (Homebrew)
    brew tap obolibrary/tools
@@ -38,6 +38,9 @@ RDFlib remains useful for Python-based data wrangling, but ROBOT's ontology-spec
    mv robot.jar ~/opt/robot/robot.jar
    printf '#!/usr/bin/env bash\nexec java -jar "$(dirname "$0")/../opt/robot/robot.jar" "$@"\n' > ~/bin/robot
    chmod +x ~/bin/robot
+
+   # Repository helper (Debian/Ubuntu)
+   scripts/install_robot_cli.sh
    ```
    Ensure `~/bin` is on your `PATH` (e.g., `echo 'export PATH="$HOME/bin:$PATH"' >> ~/.bashrc`).
 3. **Environment variables** – set `ROBOT_JAR` if invoking the jar directly; configure `JAVA_OPTS` for memory-intensive operations.

--- a/scripts/install_robot_cli.sh
+++ b/scripts/install_robot_cli.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Installs the ROBOT command-line interface along with its dependencies.
+# Designed for Debian/Ubuntu environments with apt package manager.
+
+set -euo pipefail
+
+ROBOT_VERSION="${ROBOT_VERSION:-1.9.5}"
+ROBOT_JAR_URL="https://github.com/ontodev/robot/releases/download/v${ROBOT_VERSION}/robot.jar"
+INSTALL_PREFIX="${INSTALL_PREFIX:-$HOME/opt/robot}"
+BIN_DIR="${BIN_DIR:-$HOME/bin}"
+ROBOT_JAR_PATH="${INSTALL_PREFIX}/robot.jar"
+ROBOT_WRAPPER_PATH="${BIN_DIR}/robot"
+
+log() {
+  printf '[ROBOT-SETUP] %s\n' "$1"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    return 1
+  fi
+}
+
+ensure_apt_package() {
+  local package="$1"
+  if dpkg -s "$package" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! command -v apt-get >/dev/null 2>&1; then
+    log "apt-get not available. Please install '$package' manually."
+    exit 1
+  fi
+
+  if [[ $EUID -ne 0 ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+      log "Installing '${package}' via sudo apt-get."
+      sudo apt-get update
+      sudo apt-get install -y "$package"
+    else
+      log "Please rerun this script as root or install '${package}' manually."
+      exit 1
+    fi
+  else
+    log "Installing '${package}' via apt-get."
+    apt-get update
+    apt-get install -y "$package"
+  fi
+}
+
+ensure_java() {
+  if require_command java; then
+    return
+  fi
+  ensure_apt_package openjdk-17-jre-headless
+}
+
+ensure_curl() {
+  if require_command curl; then
+    return
+  fi
+  ensure_apt_package curl
+}
+
+install_robot() {
+  mkdir -p "$INSTALL_PREFIX"
+  mkdir -p "$BIN_DIR"
+
+  log "Downloading ROBOT v${ROBOT_VERSION} from ${ROBOT_JAR_URL}."
+  curl -L -o "$ROBOT_JAR_PATH" "$ROBOT_JAR_URL"
+
+  cat > "$ROBOT_WRAPPER_PATH" <<SCRIPT
+#!/usr/bin/env bash
+exec java -jar "$ROBOT_JAR_PATH" "\$@"
+SCRIPT
+  chmod +x "$ROBOT_WRAPPER_PATH"
+}
+
+verify_installation() {
+  if ! "$ROBOT_WRAPPER_PATH" --version; then
+    log "ROBOT installation failed."
+    exit 1
+  fi
+}
+
+log "Ensuring Java runtime is available."
+ensure_java
+
+log "Ensuring curl is available for downloads."
+ensure_curl
+
+log "Installing ROBOT CLI."
+install_robot
+
+log "Verifying installation."
+verify_installation
+
+log "ROBOT CLI installation completed. Ensure '${BIN_DIR}' is on your PATH."


### PR DESCRIPTION
## Summary
- add a Debian/Ubuntu helper script that installs ROBOT and its prerequisites
- document the helper script alongside the existing ROBOT installation guidance

## Testing
- `bash -n scripts/install_robot_cli.sh`


------
https://chatgpt.com/codex/tasks/task_b_68ca580ab6908323bef621f613879a76