### PR TITLE
Plan Phase 4 alignment with Anthropogenic Impact ontologies

### DIFF
--- a/docs/ontology/phase4-alignment.md
+++ b/docs/ontology/phase4-alignment.md
@@ -1,0 +1,48 @@
+# Phase 4 External Alignment Blueprint
+
+This blueprint operationalises the Phase 4 integration goal of binding Hedera-native modules to Anthropogenic Impact Accounting ontologies. The focus is on four priority vocabularies: AIAO, CliaMont, ImpactOnt, and InfoComm.
+
+## Objectives
+
+1. **Traceability:** Preserve provenance from Hedera transactions and governance artefacts into impact reporting statements.
+2. **Semantic interoperability:** Ensure ESG, climate, and infrastructure concepts reuse established classes/properties from the external ontologies without creating logical conflicts.
+3. **Automation-readiness:** Leverage ROBOT and existing SPARQL/SHACL pipelines so bridge modules participate in automated reasoning and validation.
+
+## Deliverables
+
+| Artefact | Description | Owner | Status |
+| -------- | ----------- | ----- | ------ |
+| `ontology/src/alignment/aiao.ttl` | MIREOT-trimmed import/bridge linking Hedera consensus & token events to `aiao:ImpactAssertion` patterns. | Ontology modellers | 📝 Planned |
+| `ontology/src/alignment/cliamont.ttl` | Alignment axioms connecting sustainability commitments and scheduled actions to CliaMont mitigation/adaptation classes. | Ontology modellers | 📝 Planned |
+| `ontology/src/alignment/impactont.ttl` | Bridges HTS compliance & treasury analytics metrics to ImpactOnt KPIs with provenance annotations. | Ontology modellers | 📝 Planned |
+| `ontology/src/alignment/infocomm.ttl` | Maps Hedera/Hiero infrastructure classes (nodes, shards, pipelines) to InfoComm communication assets. | Ontology modellers | 📝 Planned |
+| `docs/mappings/aiao-alignment.csv` | Traceability matrix referencing Hedera docs/HIPs that justify each mapping. | Documentation lead | 📝 Planned |
+| `tests/queries/cq-esg-001.rq` | Competency query demonstrating cross-ontology ESG reporting. | Tooling lead | 📝 Planned |
+
+## Integration steps
+
+1. **Term scoping:**
+   * Use `robot extract --method MIREOT` to pull only the terms required to satisfy targeted competency questions.
+   * Maintain a shared `alignment-prefixes.ttl` file to control namespace declarations and avoid duplication.
+2. **Bridge modelling:**
+   * Start with `owl:equivalentClass`/`owl:subClassOf` assertions where Hedera classes are narrower than the external ontologies.
+   * Annotate every bridge axiom with `dcterms:source` linking to Hedera documentation (HIPs, service manuals) and to the relevant ontology documentation.
+3. **Validation hooks:**
+   * Extend existing ROBOT reasoning tasks to include the new alignment modules.
+   * Author SHACL shapes that verify minimum data requirements for AIAO impact statements (e.g., actor, activity, impact metric).
+4. **Pilot datasets:**
+   * Transform the ESG-focused sample data into RDF using `scripts/run_sparql.py` pipeline extensions, targeting AIAO and ImpactOnt classes.
+   * Capture feedback from ESG stakeholders and iterate on mappings before locking down equivalence axioms.
+
+## Open questions
+
+* What governance process is needed to version-sync with future AIAO/CliaMont releases?
+* Should bridge modules live in the main namespace or a dedicated `/alignment/` namespace until stabilised?
+* Can existing Hedera sustainability disclosures provide enough evidence to assert strong (equivalent) mappings, or should we start with weaker `rdfs:seeAlso` references?
+
+## References
+
+* [AIAO](https://datadudes.xyz/aiao)
+* [CliaMont](https://datadudes.xyz/cliamont)
+* [ImpactOnt](https://datadudes.xyz/impactont)
+* [InfoComm](https://datadudes.xyz/infocomm)

--- a/docs/research/ontology-landscape.md
+++ b/docs/research/ontology-landscape.md
@@ -12,6 +12,10 @@ Phase 1 requires identifying reusable vocabularies that can accelerate Bhash mod
 | [FIBO](https://spec.edmcouncil.org/fibo/) | Financial instruments & governance. | Token classifications, treasury roles, governance committees. | Scope alignment needed; avoid over-constraining token semantics. |
 | [ODRL](https://www.w3.org/TR/odrl-model/) | Policy/permission modelling. | Custom fee rules, access control statements for topics/files. | Evaluate complexity relative to simpler policy shapes. |
 | [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/) | Telemetry schema for observability. | Potential mapping for node metrics and mirror observability data. | Likely optional until telemetry integration is prioritised. |
+| [AIAO](https://datadudes.xyz/aiao) | Anthropogenic impact accounting upper ontology. | Provides environmental and social impact scaffolding for ESG reporting on Hedera-hosted assets. | Requires bridge module translating Hedera service events into impact indicators. |
+| [CliaMont](https://datadudes.xyz/cliamont) | Climate accounting ontology for mitigation/adaptation measures. | Align Hedera staking, sustainability initiatives, and carbon credit tokens with climate metrics. | Need domain expert review to avoid overstating equivalence relationships. |
+| [ImpactOnt](https://datadudes.xyz/impactont) | Ontology for modelling impact investment portfolios and KPIs. | Map Hedera token compliance and treasury analytics concepts to impact investment observables. | Ensure financial definitions complement existing FIBO alignments. |
+| [InfoComm](https://datadudes.xyz/infocomm) | Information and communication infrastructure ontology. | Useful for representing Hedera network infrastructure, mirror data pipelines, and observability dependencies. | Identify overlap with Hiero virtualization constructs before importing. |
 
 ## Detailed notes
 
@@ -50,6 +54,30 @@ Phase 1 requires identifying reusable vocabularies that can accelerate Bhash mod
 * Relevant for future monitoring use cases (node metrics, mirror API performance) mentioned in [Hedera mirror node metrics docs](https://docs.hedera.com/hedera/mirror-node/architecture/metrics).
 * Could align Hiero observability artefacts with standard telemetry terms.
 * Next step: catalogue which metrics are publicly exposed to gauge scope.
+
+### AIAO
+
+* Emphasises anthropogenic impact indicators (environmental, social, governance) that downstream reporting platforms require.
+* Hedera token and treasury analytics modules can expose activity traces (e.g., sustainability-linked tokens, carbon offsets) as `aiao:ImpactAssertion` instances referencing consensus transactions.
+* Next step: design a bridge shape that consumes Hedera transaction provenance and emits AIAO-compatible impact statements for ESG pilots.
+
+### CliaMont
+
+* Focused on climate mitigation/adaptation measures, emissions accounting, and policy instruments.
+* Scheduled transactions and governance artefacts can document climate-related commitments by mapping to `cliamont:ClimateAction` and `cliamont:MitigationMeasure` classes.
+* Next step: convene with Hedera sustainability programme owners to validate which ledger events constitute authoritative climate actions.
+
+### ImpactOnt
+
+* Models impact investment theses, KPIs, and measurement frameworks used by ESG funds.
+* HTS compliance and treasury analytics data can populate `impactont:ImpactMetric` observations, linking to underlying token supply/movement events.
+* Next step: create competency questions covering impact reporting (e.g., "Which Hedera-issued tokens contribute to SDG-aligned KPIs?") and prototype SPARQL mappings to ImpactOnt terms.
+
+### InfoComm
+
+* Provides vocabulary for communication infrastructure, data flows, and service dependencies.
+* Aligns with Hedera mirror node and Hiero virtualization constructs, enabling explicit modelling of data pipelines and observability hooks.
+* Next step: assess overlap with existing network topology classes in the core and mirror modules, then define equivalence or subClassOf relations where semantics align.
 
 ## Action items
 

--- a/docs/workplan.md
+++ b/docs/workplan.md
@@ -118,7 +118,11 @@ Each module should deliver:
 
 * **Cross-module consistency:** Run reasoning to ensure shared classes/properties do not conflict; refactor to maintain OWL DL compliance.
 * **External alignment:** Create equivalence/subClassOf relations to external ontologies, document alignments, and resolve semantic gaps.
+  * Prioritise Anthropogenic Impact Accounting Ontology (AIAO), CliaMont, ImpactOnt, and InfoComm mappings so Hedera ESG, sustainability, and infrastructure narratives can reuse established semantics.
+  * Produce ROBOT templates for bridge modules (`ontology/src/alignment/aiao.ttl`, etc.) that materialise `owl:equivalentClass`/`owl:subClassOf` axioms and annotate provenance back to Hedera documentation.
+  * Schedule expert review workshops with ESG stakeholders to validate impact- and climate-focused alignments before asserting strong equivalences.
 * **Data pilots:** Load sample data (mirror node exports, HIP reference payloads) into a triple store (e.g., GraphDB, Blazegraph) and validate SHACL constraints.
+  * Extend pilots with ESG-oriented exemplars that transform consensus transactions into AIAO `ImpactAssertion` instances and demonstrate cross-ontology query answering.
 
 ## Phase 5 – Publication & automation (Weeks 13-14)
 


### PR DESCRIPTION
## Summary
- extend the external ontology landscape review with AIAO, CliaMont, ImpactOnt, and InfoComm alignment notes
- update the Phase 4 workplan to prioritise Anthropogenic Impact Accounting bridges and ESG-focused data pilots
- document a Phase 4 alignment blueprint detailing deliverables, integration steps, and open questions for the new ontologies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ca6c363ff48323a0482e2c731c3ad1