### PR TITLE
Update ClaimOnt alignment references

### DIFF
--- a/docs/competency/esg-alignment.md
+++ b/docs/competency/esg-alignment.md
@@ -7,7 +7,7 @@ Phase 4 introduces the cross-ontology assets required to exercise CQ-ESG-001 and
 * **Status:** Prototype ontology bridges, sample graph, and SPARQL query committed.
 * **Scope:** Show how scheduled mitigation actions funded on Hedera surface as AIAO impact assertions with provenance to mirror datasets and sustainability KPIs.
 * **Inputs:**
-  * Ontology: `ontology/src/alignment/aiao.ttl`, `ontology/src/alignment/cliamont.ttl`, `ontology/src/alignment/impactont.ttl`, `ontology/src/alignment/infocomm.ttl`
+  * Ontology: `ontology/src/alignment/aiao.ttl`, `ontology/src/alignment/claimont.ttl`, `ontology/src/alignment/impactont.ttl`, `ontology/src/alignment/infocomm.ttl`
   * Sample graph: `ontology/examples/alignment-esg.ttl`
   * Query: `tests/queries/cq-esg-001.rq`
 
@@ -15,7 +15,7 @@ Phase 4 introduces the cross-ontology assets required to exercise CQ-ESG-001 and
 
 1. Load the core and alignment ontologies alongside the ESG sample graph into an RDF store.
 2. Execute the SPARQL query to retrieve each `aiao:ImpactAssertion`, its Hedera subject, associated KPI metrics, optional SDG goal, related scheduled mitigation action, and the communication node exposing evidence datasets.
-3. Review the results to verify that Hedera concepts inherit semantics from AIAO, CliaMont, ImpactOnt, and InfoComm through the bridge axioms.
+3. Review the results to verify that Hedera concepts inherit semantics from AIAO, ClaimOnt, ImpactOnt, and InfoComm through the bridge axioms.
 
 ### Sample result (derived from `ontology/examples/alignment-esg.ttl`)
 

--- a/docs/ontology/phase4-alignment.md
+++ b/docs/ontology/phase4-alignment.md
@@ -1,6 +1,6 @@
 # Phase 4 External Alignment Blueprint
 
-This blueprint operationalises the Phase 4 integration goal of binding Hedera-native modules to Anthropogenic Impact Accounting ontologies. The focus is on four priority vocabularies: AIAO, CliaMont, ImpactOnt, and InfoComm.
+This blueprint operationalises the Phase 4 integration goal of binding Hedera-native modules to Anthropogenic Impact Accounting ontologies. The focus is on four priority vocabularies: AIAO, ClaimOnt, ImpactOnt, and InfoComm.
 
 ## Objectives
 
@@ -13,7 +13,7 @@ This blueprint operationalises the Phase 4 integration goal of binding Hedera-na
 | Artefact | Description | Owner | Status |
 | -------- | ----------- | ----- | ------ |
 | `ontology/src/alignment/aiao.ttl` | MIREOT-trimmed import/bridge linking Hedera consensus & token events to `aiao:ImpactAssertion` patterns. | Ontology modellers | 🔄 In progress |
-| `ontology/src/alignment/cliamont.ttl` | Alignment axioms connecting sustainability commitments and scheduled actions to CliaMont mitigation/adaptation classes. | Ontology modellers | 🔄 In progress |
+| `ontology/src/alignment/claimont.ttl` | Alignment axioms connecting sustainability commitments and scheduled actions to ClaimOnt mitigation/adaptation classes. | Ontology modellers | 🔄 In progress |
 | `ontology/src/alignment/impactont.ttl` | Bridges HTS compliance & treasury analytics metrics to ImpactOnt KPIs with provenance annotations. | Ontology modellers | 🔄 In progress |
 | `ontology/src/alignment/infocomm.ttl` | Maps Hedera/Hiero infrastructure classes (nodes, shards, pipelines) to InfoComm communication assets. | Ontology modellers | 🔄 In progress |
 | `docs/mappings/aiao-alignment.csv` | Traceability matrix referencing Hedera docs/HIPs that justify each mapping. | Documentation lead | ✅ Complete |
@@ -36,13 +36,13 @@ This blueprint operationalises the Phase 4 integration goal of binding Hedera-na
 
 ## Open questions
 
-* What governance process is needed to version-sync with future AIAO/CliaMont releases?
+* What governance process is needed to version-sync with future AIAO/ClaimOnt releases?
 * Should bridge modules live in the main namespace or a dedicated `/alignment/` namespace until stabilised?
 * Can existing Hedera sustainability disclosures provide enough evidence to assert strong (equivalent) mappings, or should we start with weaker `rdfs:seeAlso` references?
 
 ## References
 
 * [AIAO](https://datadudes.xyz/aiao)
-* [CliaMont](https://datadudes.xyz/cliamont)
+* [ClaimOnt](https://datadudes.xyz/claimont)
 * [ImpactOnt](https://datadudes.xyz/impactont)
 * [InfoComm](https://datadudes.xyz/infocomm)

--- a/docs/research/ontology-landscape.md
+++ b/docs/research/ontology-landscape.md
@@ -13,7 +13,7 @@ Phase 1 requires identifying reusable vocabularies that can accelerate Bhash mod
 | [ODRL](https://www.w3.org/TR/odrl-model/) | Policy/permission modelling. | Custom fee rules, access control statements for topics/files. | Evaluate complexity relative to simpler policy shapes. |
 | [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/) | Telemetry schema for observability. | Potential mapping for node metrics and mirror observability data. | Likely optional until telemetry integration is prioritised. |
 | [AIAO](https://datadudes.xyz/aiao) | Anthropogenic impact accounting upper ontology. | Provides environmental and social impact scaffolding for ESG reporting on Hedera-hosted assets. | Requires bridge module translating Hedera service events into impact indicators. |
-| [CliaMont](https://datadudes.xyz/cliamont) | Climate accounting ontology for mitigation/adaptation measures. | Align Hedera staking, sustainability initiatives, and carbon credit tokens with climate metrics. | Need domain expert review to avoid overstating equivalence relationships. |
+| [ClaimOnt](https://datadudes.xyz/claimont) | Climate accounting ontology for mitigation/adaptation measures. | Align Hedera staking, sustainability initiatives, and carbon credit tokens with climate metrics. | Need domain expert review to avoid overstating equivalence relationships. |
 | [ImpactOnt](https://datadudes.xyz/impactont) | Ontology for modelling impact investment portfolios and KPIs. | Map Hedera token compliance and treasury analytics concepts to impact investment observables. | Ensure financial definitions complement existing FIBO alignments. |
 | [InfoComm](https://datadudes.xyz/infocomm) | Information and communication infrastructure ontology. | Useful for representing Hedera network infrastructure, mirror data pipelines, and observability dependencies. | Identify overlap with Hiero virtualization constructs before importing. |
 
@@ -61,10 +61,10 @@ Phase 1 requires identifying reusable vocabularies that can accelerate Bhash mod
 * Hedera token and treasury analytics modules can expose activity traces (e.g., sustainability-linked tokens, carbon offsets) as `aiao:ImpactAssertion` instances referencing consensus transactions.
 * Next step: design a bridge shape that consumes Hedera transaction provenance and emits AIAO-compatible impact statements for ESG pilots.
 
-### CliaMont
+### ClaimOnt
 
 * Focused on climate mitigation/adaptation measures, emissions accounting, and policy instruments.
-* Scheduled transactions and governance artefacts can document climate-related commitments by mapping to `cliamont:ClimateAction` and `cliamont:MitigationMeasure` classes.
+* Scheduled transactions and governance artefacts can document climate-related commitments by mapping to `claimont:ClimateAction` and `claimont:MitigationMeasure` classes.
 * Next step: convene with Hedera sustainability programme owners to validate which ledger events constitute authoritative climate actions.
 
 ### ImpactOnt

--- a/docs/workplan.md
+++ b/docs/workplan.md
@@ -118,7 +118,7 @@ Each module should deliver:
 
 * **Cross-module consistency:** Run reasoning to ensure shared classes/properties do not conflict; refactor to maintain OWL DL compliance.
 * **External alignment:** Create equivalence/subClassOf relations to external ontologies, document alignments, and resolve semantic gaps.
-  * Prioritise Anthropogenic Impact Accounting Ontology (AIAO), CliaMont, ImpactOnt, and InfoComm mappings so Hedera ESG, sustainability, and infrastructure narratives can reuse established semantics.
+  * Prioritise Anthropogenic Impact Accounting Ontology (AIAO), ClaimOnt, ImpactOnt, and InfoComm mappings so Hedera ESG, sustainability, and infrastructure narratives can reuse established semantics.
   * Produce ROBOT templates for bridge modules (`ontology/src/alignment/aiao.ttl`, etc.) that materialise `owl:equivalentClass`/`owl:subClassOf` axioms and annotate provenance back to Hedera documentation.
   * Schedule expert review workshops with ESG stakeholders to validate impact- and climate-focused alignments before asserting strong equivalences.
 * **Data pilots:** Load sample data (mirror node exports, HIP reference payloads) into a triple store (e.g., GraphDB, Blazegraph) and validate SHACL constraints.
@@ -146,7 +146,7 @@ Each module should deliver:
 | 10 | Plan File/Scheduled Transactions and Mirror/Analytics sprints with dependency on shared datasets. | ✅ Complete | File/Schedule, Mirror/Analytics, and Hiero modules shipped with shared fixtures enabling regression automation. |
 | 11 | Integrate mirror node HTS precompile traces into automated ETL prototype. | 📝 Planned | Extend `data/contracts/hts-precompiles/` with live extracts and script transformation into RDF for regression tests. |
 | 12 | Expand treasury analytics competency with real balance snapshots. | 📝 Planned | Populate `data/mirror/token-balance-retention.csv` with operational SLAs and ingest sample mirror balance exports. |
-| 13 | Initiate Phase 4 alignment sprint focusing on AIAO equivalences. | 🔄 In progress | Alignment namespace created with initial AIAO/CliaMont/ImpactOnt/InfoComm bridge modules plus ESG query fixture. |
+| 13 | Initiate Phase 4 alignment sprint focusing on AIAO equivalences. | 🔄 In progress | Alignment namespace created with initial AIAO/ClaimOnt/ImpactOnt/InfoComm bridge modules plus ESG query fixture. |
 
 ## Risk considerations
 

--- a/ontology/examples/alignment-esg.ttl
+++ b/ontology/examples/alignment-esg.ttl
@@ -1,7 +1,7 @@
 @prefix ex: <https://bhash.dev/examples/esg/> .
 @prefix hedera: <https://bhash.dev/hedera/core/> .
 @prefix aiao: <https://datadudes.xyz/ontology/aiao#> .
-@prefix cliamont: <https://datadudes.xyz/ontology/cliamont#> .
+@prefix claimont: <https://datadudes.xyz/claimont#> .
 @prefix impactont: <https://datadudes.xyz/ontology/impactont#> .
 @prefix infocomm: <https://datadudes.xyz/ontology/infocomm#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -34,7 +34,7 @@ infocomm:SLA-EcoTelemetry
     .
 
 ex:ReforestationImpactStatement
-    a cliamont:ImpactStatement ;
+    a claimont:ImpactStatement ;
     rdfs:label "Q4 Reforestation Impact Statement"@en ;
     .
 
@@ -88,11 +88,11 @@ ex:ReforestationSchedule
     hedera:hasClimateWindow "2024-Q4" ;
     hedera:linkedImpactAssertion ex:ReforestationImpactStatement ;
     hedera:tracksResilienceMilestone ex:HieroUpgradeQ4 ;
-    hedera:advancesClimateObjective cliamont:ForestRestorationObjective ;
+    hedera:advancesClimateObjective claimont:ForestRestorationObjective ;
     .
 
-cliamont:ForestRestorationObjective
-    a cliamont:ClimateObjective ;
+claimont:ForestRestorationObjective
+    a claimont:ClimateObjective ;
     rdfs:label "Forest Restoration Objective"@en ;
     .
 

--- a/ontology/src/alignment/claimont.ttl
+++ b/ontology/src/alignment/claimont.ttl
@@ -1,6 +1,6 @@
-@prefix : <https://bhash.dev/hedera/alignment/cliamont/> .
+@prefix : <https://bhash.dev/hedera/alignment/claimont/> .
 @prefix hedera: <https://bhash.dev/hedera/core/> .
-@prefix cliamont: <https://datadudes.xyz/ontology/cliamont#> .
+@prefix claimont: <https://datadudes.xyz/claimont#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -9,17 +9,17 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://bhash.dev/hedera/alignment/cliamont>
+<https://bhash.dev/hedera/alignment/claimont>
     a owl:Ontology ;
-    dcterms:title "CliaMont alignment module"@en ;
-    dcterms:description "Aligns Hedera scheduled transactions and governance commitments with CliaMont climate mitigation and adaptation concepts."@en ;
+    dcterms:title "ClaimOnt alignment module"@en ;
+    dcterms:description "Aligns Hedera scheduled transactions and governance commitments with ClaimOnt climate mitigation and adaptation concepts."@en ;
     dcterms:creator "Bhash Ontology Working Group"@en ;
     dcterms:created "2025-10-01"^^xsd:date ;
     dcterms:modified "2025-10-01"^^xsd:date ;
     owl:imports <https://bhash.dev/hedera/core> ,
         <https://bhash.dev/hedera/file-schedule> ;
     owl:versionInfo "0.1.0-dev" ;
-    skos:editorialNote "Phase 4 bridge module mapping scheduled sustainability actions to CliaMont mitigation and adaptation taxonomies."@en ;
+    skos:editorialNote "Phase 4 bridge module mapping scheduled sustainability actions to ClaimOnt mitigation and adaptation taxonomies."@en ;
     .
 
 ###
@@ -30,30 +30,30 @@ hedera:ScheduledMitigationAction
     a owl:Class ;
     rdfs:label "Scheduled mitigation action"@en ;
     rdfs:subClassOf hedera:ScheduledTransaction ,
-        cliamont:MitigationAction ;
+        claimont:MitigationAction ;
     skos:definition "Scheduled transaction whose execution funds or enables a climate mitigation activity."@en ;
     hedera:sourceDocument <https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/introduction> ;
-    dcterms:source <https://datadudes.xyz/cliamont#MitigationAction> ;
+    dcterms:source <https://datadudes.xyz/claimont#MitigationAction> ;
     .
 
 hedera:ClimateAdaptationSchedule
     a owl:Class ;
     rdfs:label "Climate adaptation schedule"@en ;
     rdfs:subClassOf hedera:ScheduledTransaction ,
-        cliamont:AdaptationCommitment ;
+        claimont:AdaptationCommitment ;
     skos:definition "Scheduled transaction capturing staged funding for adaptation programmes."@en ;
     hedera:sourceDocument <https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work> ;
-    dcterms:source <https://datadudes.xyz/cliamont#AdaptationCommitment> ;
+    dcterms:source <https://datadudes.xyz/claimont#AdaptationCommitment> ;
     .
 
 hedera:ResilienceMilestone
     a owl:Class ;
     rdfs:label "Resilience milestone"@en ;
     rdfs:subClassOf hedera:Event ,
-        cliamont:ResilienceOutcome ;
+        claimont:ResilienceOutcome ;
     skos:definition "Network event used as a milestone for tracking adaptation commitments."@en ;
     hedera:sourceDocument <https://docs.hedera.com/hiero/roadmap> ;
-    dcterms:source <https://datadudes.xyz/cliamont#ResilienceOutcome> ;
+    dcterms:source <https://datadudes.xyz/claimont#ResilienceOutcome> ;
     .
 
 ###
@@ -64,22 +64,22 @@ hedera:advancesClimateObjective
     a owl:ObjectProperty ;
     rdfs:label "advances climate objective"@en ;
     rdfs:domain hedera:ScheduledTransaction ;
-    rdfs:range cliamont:ClimateObjective ;
-    rdfs:subPropertyOf cliamont:advancesObjective ;
+    rdfs:range claimont:ClimateObjective ;
+    rdfs:subPropertyOf claimont:advancesObjective ;
     skos:definition "Associates a scheduled transaction with the climate objective it advances."@en ;
     hedera:sourceDocument <https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/introduction> ;
-    dcterms:source <https://datadudes.xyz/cliamont#advancesObjective> ;
+    dcterms:source <https://datadudes.xyz/claimont#advancesObjective> ;
     .
 
 hedera:linkedImpactAssertion
     a owl:ObjectProperty ;
     rdfs:label "linked impact assertion"@en ;
     rdfs:domain hedera:ScheduledTransaction ;
-    rdfs:range cliamont:ImpactStatement ;
-    rdfs:subPropertyOf cliamont:documentsOutcome ;
+    rdfs:range claimont:ImpactStatement ;
+    rdfs:subPropertyOf claimont:documentsOutcome ;
     skos:definition "Connects a scheduled action to the impact statement documenting its execution."@en ;
     hedera:sourceDocument <https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work> ;
-    dcterms:source <https://datadudes.xyz/cliamont#ImpactStatement> ;
+    dcterms:source <https://datadudes.xyz/claimont#ImpactStatement> ;
     .
 
 hedera:tracksResilienceMilestone
@@ -87,10 +87,10 @@ hedera:tracksResilienceMilestone
     rdfs:label "tracks resilience milestone"@en ;
     rdfs:domain hedera:ScheduledTransaction ;
     rdfs:range hedera:ResilienceMilestone ;
-    rdfs:subPropertyOf cliamont:monitorsIndicator ;
+    rdfs:subPropertyOf claimont:monitorsIndicator ;
     skos:definition "Identifies the network milestone used to evidence progress against a climate action."@en ;
     hedera:sourceDocument <https://docs.hedera.com/hiero/roadmap> ;
-    dcterms:source <https://datadudes.xyz/cliamont#monitorsIndicator> ;
+    dcterms:source <https://datadudes.xyz/claimont#monitorsIndicator> ;
     .
 
 hedera:hasClimateWindow
@@ -98,8 +98,8 @@ hedera:hasClimateWindow
     rdfs:label "has climate window"@en ;
     rdfs:domain hedera:ScheduledTransaction ;
     rdfs:range xsd:string ;
-    rdfs:subPropertyOf cliamont:hasReportingPeriod ;
+    rdfs:subPropertyOf claimont:hasReportingPeriod ;
     skos:definition "Specifies the reporting period for a scheduled climate commitment."@en ;
     hedera:sourceDocument <https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work> ;
-    dcterms:source <https://datadudes.xyz/cliamont#hasReportingPeriod> ;
+    dcterms:source <https://datadudes.xyz/claimont#hasReportingPeriod> ;
     .

--- a/ontology/src/alignment/prefixes.ttl
+++ b/ontology/src/alignment/prefixes.ttl
@@ -1,6 +1,6 @@
 @prefix hedera: <https://bhash.dev/hedera/core/> .
 @prefix aiao: <https://datadudes.xyz/ontology/aiao#> .
-@prefix cliamont: <https://datadudes.xyz/ontology/cliamont#> .
+@prefix claimont: <https://datadudes.xyz/claimont#> .
 @prefix impactont: <https://datadudes.xyz/ontology/impactont#> .
 @prefix infocomm: <https://datadudes.xyz/ontology/infocomm#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .

--- a/tests/queries/cq-esg-001.rq
+++ b/tests/queries/cq-esg-001.rq
@@ -1,6 +1,6 @@
 PREFIX hedera: <https://bhash.dev/hedera/core/>
 PREFIX aiao: <https://datadudes.xyz/ontology/aiao#>
-PREFIX cliamont: <https://datadudes.xyz/ontology/cliamont#>
+PREFIX claimont: <https://datadudes.xyz/claimont#>
 PREFIX impactont: <https://datadudes.xyz/ontology/impactont#>
 PREFIX infocomm: <https://datadudes.xyz/ontology/infocomm#>
 
@@ -19,7 +19,7 @@ WHERE {
 
   OPTIONAL {
     ?assertion hedera:deliveredBySchedule ?schedule .
-    ?schedule a cliamont:MitigationAction .
+    ?schedule a claimont:MitigationAction .
   }
 
   OPTIONAL {


### PR DESCRIPTION
## Summary
- switch the ESG query, example graph, and prefix module to use the correct ClaimOnt namespace at https://datadudes.xyz/claimont
- rename the alignment bridge file to claimont.ttl and refresh its metadata and axioms to reference ClaimOnt
- update documentation to point to ClaimOnt resources and terminology

## Testing
- `make sparql`


------
https://chatgpt.com/codex/tasks/task_b_68ca7c2cb394832399092c253bc782d4