### PR TITLE
Add Fluree Cloud client and testing harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 VENV_DIR := build/venv
 PYTHON_BIN := $(VENV_DIR)/bin/python
 
-.PHONY: all reason-core report-core template-example shacl sparql python-venv clean
+.PHONY: all reason-core report-core template-example shacl sparql fluree-smoke python-venv clean
 
 all: reason-core report-core shacl sparql
 
@@ -30,6 +30,9 @@ shacl: python-venv
 
 sparql: python-venv
 	$(PYTHON_BIN) scripts/run_sparql.py
+
+fluree-smoke: python-venv
+	$(PYTHON_BIN) -m pytest -m fluree_smoke tests/test_fluree_client.py
 
 clean:
 	rm -rf build

--- a/docs/tooling/toolchain.md
+++ b/docs/tooling/toolchain.md
@@ -46,6 +46,18 @@ RDFlib remains useful for Python-based data wrangling, but ROBOT's ontology-spec
 3. **Environment variables** – set `ROBOT_JAR` if invoking the jar directly; configure `JAVA_OPTS` for memory-intensive operations.
 4. **Project scripts** – the repository `Makefile` now wraps ROBOT, SHACL, and SPARQL commands so contributors can run the full toolchain with a single dependency bootstrap.
 
+### Fluree Cloud credentials
+
+Phase A introduces a lightweight Python client for the Fluree Cloud HTTP API. Networked tests and CLI helpers expect the following environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `FLUREE_API_TOKEN` | Bearer token generated in the Fluree Cloud console. |
+| `FLUREE_HANDLE` | Tenant handle that prefixes Cloud API routes. |
+| `FLUREE_BASE_URL` (optional) | Override for non-production tenants; defaults to `https://data.flur.ee`. |
+
+Integration tests marked with `@pytest.mark.fluree_live` remain skipped unless both the credentials are present **and** `pytest` is invoked with `--run-fluree`. Offline smoke tests use mocked HTTP responses and are safe to run by default.
+
 ## Codex collaboration guidelines
 
 1. **Prompt hygiene** – share relevant documentation excerpts when asking Codex for modelling assistance to maintain traceability.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 pyshacl>=0.20.0
 rdflib>=6.3.2
+requests>=2.31.0
+responses>=0.25.0
+pytest>=7.4.0

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,2 @@
+"""Helper scripts for ontology tooling and integrations."""
+

--- a/scripts/fluree_client.py
+++ b/scripts/fluree_client.py
@@ -1,0 +1,170 @@
+"""Utilities for interacting with the Fluree Cloud HTTP API.
+
+This module centralises authentication headers, request/response logging,
+and the small set of API endpoints we rely on for the initial integration
+work.  The design keeps dependencies intentionally lightweight so it can be
+used by both command-line scripts and pytest fixtures without pulling in
+framework-specific helpers.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class FlureeClientError(RuntimeError):
+    """Raised when the Fluree API responds with an error."""
+
+
+class FlureeConfigurationError(FlureeClientError):
+    """Raised when the client cannot be configured from the environment."""
+
+
+@dataclass(frozen=True)
+class FlureeConfig:
+    """Configuration bundle for :class:`FlureeClient`."""
+
+    api_token: str
+    tenant_handle: str
+    base_url: str = "https://data.flur.ee"
+
+    @classmethod
+    def from_env(cls) -> "FlureeConfig":
+        """Build a configuration object from environment variables.
+
+        Expected variables:
+
+        ``FLUREE_API_TOKEN``
+            API token issued via the Fluree Cloud console.
+
+        ``FLUREE_HANDLE``
+            Tenant handle used as the path prefix for Cloud HTTP endpoints.
+
+        ``FLUREE_BASE_URL`` (optional)
+            Override the API base URL; defaults to ``https://data.flur.ee``.
+        """
+
+        api_token = os.getenv("FLUREE_API_TOKEN")
+        tenant_handle = os.getenv("FLUREE_HANDLE")
+        base_url = os.getenv("FLUREE_BASE_URL", cls.base_url)
+
+        missing = [name for name, value in {
+            "FLUREE_API_TOKEN": api_token,
+            "FLUREE_HANDLE": tenant_handle,
+        }.items() if not value]
+
+        if missing:
+            raise FlureeConfigurationError(
+                "Missing environment variables: " + ", ".join(sorted(missing))
+            )
+
+        return cls(api_token=api_token or "", tenant_handle=tenant_handle or "", base_url=base_url)
+
+
+class FlureeClient:
+    """Minimal Fluree Cloud client with JSON helper methods."""
+
+    def __init__(self, config: FlureeConfig, session: Optional[requests.Session] = None) -> None:
+        self.config = config
+        self._session = session or requests.Session()
+
+    # -- HTTP helpers -------------------------------------------------
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.config.api_token}",
+            "x-user-handle": self.config.tenant_handle,
+            "Content-Type": "application/json",
+        }
+
+    def _post(self, path: str, payload: Mapping[str, Any]) -> Any:
+        url = f"{self.config.base_url.rstrip('/')}/{path.lstrip('/')}"
+        logger.debug("POST %s payload=%s", url, json.dumps(payload, ensure_ascii=False))
+        try:
+            response = self._session.post(url, headers=self._headers(), json=payload, timeout=30)
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            raise FlureeClientError(f"Error connecting to {url}: {exc}") from exc
+
+        if response.status_code >= 400:
+            message = self._format_error(response)
+            logger.error("Fluree API error %s: %s", response.status_code, message)
+            raise FlureeClientError(message)
+
+        if not response.content:
+            return None
+        try:
+            return response.json()
+        except ValueError:  # pragma: no cover - unexpected payloads
+            logger.debug("Response not JSON, returning text")
+            return response.text
+
+    @staticmethod
+    def _format_error(response: requests.Response) -> str:
+        try:
+            data = response.json()
+        except ValueError:
+            return f"HTTP {response.status_code}: {response.text}"
+        if isinstance(data, Mapping):
+            message = data.get("message") or data.get("error") or data
+            return f"HTTP {response.status_code}: {message}"
+        return f"HTTP {response.status_code}: {data}"
+
+    # -- API surface --------------------------------------------------
+
+    def create_dataset(self, owner_handle: str, *, dataset_name: str, storage_type: str,
+                       description: str, visibility: str = "private",
+                       tags: Optional[Iterable[str]] = None) -> Any:
+        payload: MutableMapping[str, Any] = {
+            "datasetName": dataset_name,
+            "storageType": storage_type,
+            "description": description,
+            "visibility": visibility,
+        }
+        if tags:
+            payload["tags"] = list(tags)
+        path = f"api/{owner_handle}/create-dataset"
+        return self._post(path, payload)
+
+    def transact(self, *, ledger: str, insert: Optional[Iterable[Mapping[str, Any]]] = None,
+                 delete: Optional[Iterable[Mapping[str, Any]]] = None,
+                 where: Optional[Iterable[Mapping[str, Any]]] = None,
+                 context: Optional[Mapping[str, Any]] = None) -> Any:
+        payload: Dict[str, Any] = {"ledger": ledger}
+        if context is not None:
+            payload["context"] = context
+        if insert is not None:
+            payload["insert"] = list(insert)
+        if delete is not None:
+            payload["delete"] = list(delete)
+        if where is not None:
+            payload["where"] = list(where)
+        return self._post("fluree/transact", payload)
+
+    def generate_prompt(self, owner_handle: str, *, datasets: Iterable[str], prompt: str) -> Any:
+        payload = {"datasets": list(datasets), "prompt": prompt}
+        return self._post(f"api/{owner_handle}/generate-prompt", payload)
+
+    def generate_sparql(self, owner_handle: str, *, datasets: Iterable[str], question: str) -> Any:
+        payload = {"datasets": list(datasets), "prompt": question}
+        return self._post(f"api/{owner_handle}/generate-sparql", payload)
+
+    def generate_answer(self, owner_handle: str, *, datasets: Iterable[str], question: str) -> Any:
+        payload = {"datasets": list(datasets), "prompt": question}
+        return self._post(f"api/{owner_handle}/generate-answer", payload)
+
+
+__all__ = [
+    "FlureeClient",
+    "FlureeClientError",
+    "FlureeConfigurationError",
+    "FlureeConfig",
+]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,64 @@
+"""Pytest fixtures for the Fluree integration."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional
+
+import pytest
+
+from scripts.fluree_client import FlureeClient, FlureeConfig, FlureeConfigurationError
+
+FLUREE_ENV_VARS = ("FLUREE_API_TOKEN", "FLUREE_HANDLE")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--run-fluree",
+        action="store_true",
+        default=False,
+        help="Run tests that communicate with Fluree Cloud",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "fluree_live: marks tests requiring Fluree Cloud")
+    config.addinivalue_line(
+        "markers",
+        "fluree_smoke: quick offline smoke tests for the Fluree client",
+    )
+
+
+@pytest.fixture(scope="session")
+def fluree_credentials() -> Optional[Dict[str, str]]:
+    """Return configured Fluree credentials or ``None`` when absent."""
+
+    values = {name: os.getenv(name) for name in FLUREE_ENV_VARS}
+    missing = [name for name, value in values.items() if not value]
+    if missing:
+        return None
+    values["FLUREE_BASE_URL"] = os.getenv("FLUREE_BASE_URL", "https://data.flur.ee")
+    return values  # type: ignore[return-value]
+
+
+@pytest.fixture
+def fluree_client_live(fluree_credentials: Optional[Dict[str, str]], request: pytest.FixtureRequest) -> FlureeClient:
+    """Instantiate a :class:`FlureeClient` when credentials are available."""
+
+    if not request.config.getoption("--run-fluree"):
+        pytest.skip("Pass --run-fluree to execute Fluree Cloud tests")
+
+    if not fluree_credentials:
+        pytest.skip("Fluree Cloud credentials are not configured")
+
+    try:
+        config = FlureeConfig(
+            api_token=fluree_credentials["FLUREE_API_TOKEN"],
+            tenant_handle=fluree_credentials["FLUREE_HANDLE"],
+            base_url=fluree_credentials["FLUREE_BASE_URL"],
+        )
+    except KeyError as exc:  # pragma: no cover - defensive guardrail
+        raise FlureeConfigurationError(f"Missing credential key: {exc}") from exc
+
+    return FlureeClient(config=config)
+

--- a/tests/test_fluree_client.py
+++ b/tests/test_fluree_client.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import responses
+
+from scripts.fluree_client import (
+    FlureeClient,
+    FlureeClientError,
+    FlureeConfig,
+    FlureeConfigurationError,
+)
+
+
+@pytest.fixture
+def client() -> FlureeClient:
+    config = FlureeConfig(api_token="token", tenant_handle="tenant")
+    return FlureeClient(config)
+
+
+@responses.activate
+def test_generate_prompt_posts_expected_payload(client: FlureeClient) -> None:
+    url = "https://data.flur.ee/api/tenant/generate-prompt"
+    responses.post(url, json={"prompt": "SELECT *"}, status=200)
+
+    result = client.generate_prompt("tenant", datasets=["tenant/sample"], prompt="List")
+
+    assert result == {"prompt": "SELECT *"}
+    call = responses.calls[0]
+    assert json.loads(call.request.body) == {
+        "datasets": ["tenant/sample"],
+        "prompt": "List",
+    }
+    assert call.request.headers["Authorization"] == "Bearer token"
+    assert call.request.headers["x-user-handle"] == "tenant"
+
+
+@responses.activate
+def test_transact_includes_optional_blocks(client: FlureeClient) -> None:
+    url = "https://data.flur.ee/fluree/transact"
+    responses.post(url, json={"status": "ok"}, status=200)
+
+    payload = {
+        "ledger": "tenant/sample",
+        "context": {"@context": {"ex": "https://example.com/"}},
+        "insert": [{"@id": "ex:thing", "@type": "ex:Class"}],
+        "delete": [],
+        "where": [{"@id": "ex:thing"}],
+    }
+    client.transact(
+        ledger="tenant/sample",
+        context=payload["context"],
+        insert=payload["insert"],
+        delete=payload["delete"],
+        where=payload["where"],
+    )
+
+    sent_body = json.loads(responses.calls[0].request.body)
+    assert sent_body == payload
+
+
+@responses.activate
+def test_error_response_raises(client: FlureeClient) -> None:
+    url = "https://data.flur.ee/api/tenant/generate-sparql"
+    responses.post(url, json={"message": "No dataset"}, status=404)
+
+    with pytest.raises(FlureeClientError) as excinfo:
+        client.generate_sparql("tenant", datasets=["missing"], question="Where")
+
+    assert "HTTP 404" in str(excinfo.value)
+
+
+def test_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FLUREE_API_TOKEN", "abc")
+    monkeypatch.setenv("FLUREE_HANDLE", "tenant")
+    monkeypatch.setenv("FLUREE_BASE_URL", "https://override")
+
+    config = FlureeConfig.from_env()
+    assert config.api_token == "abc"
+    assert config.tenant_handle == "tenant"
+    assert config.base_url == "https://override"
+
+
+def test_config_from_env_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FLUREE_API_TOKEN", raising=False)
+    monkeypatch.delenv("FLUREE_HANDLE", raising=False)
+
+    with pytest.raises(FlureeConfigurationError):
+        FlureeConfig.from_env()
+
+
+@responses.activate
+@pytest.mark.fluree_smoke
+def test_smoke_generate_answer(client: FlureeClient) -> None:
+    url = "https://data.flur.ee/api/tenant/generate-answer"
+    responses.post(url, json={"answer": "Sample"}, status=200)
+
+    result = client.generate_answer("tenant", datasets=["tenant/sample"], question="Q")
+
+    assert result == {"answer": "Sample"}
+


### PR DESCRIPTION
## Summary
- add a reusable Fluree Cloud API client with helpers for dataset, transact, and LLM endpoints
- introduce pytest fixtures and mocked smoke tests plus a Makefile target to exercise the client
- document required Fluree credentials and extend project dependencies for testing utilities

## Testing
- `make fluree-smoke`
- `build/venv/bin/python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ca97b888188323af9c9f743ef2c1eb