### PR TITLE
Add Go tooling for ROBOT automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ python scripts/run_shacl.py    # Runs SHACL validation across aggregated example
 
 Both scripts materialise outputs under `build/` (created on demand) and report any mismatches with expected fixtures.
 
+### Go-based automation
+
+If you prefer to avoid the Python toolchain, the repository also provides a Go CLI that installs the [ROBOT](https://github.com/ontodev/robot) and [TopBraid SHACL](https://github.com/TopQuadrant/shacl) command-line tools and mirrors the regression checks:
+
+```bash
+go run ./cmd/bhashctl install  # Downloads ROBOT + SHACL into build/tools
+go run ./cmd/bhashctl sparql   # Executes all SPARQL regression queries via ROBOT
+go run ./cmd/bhashctl shacl    # Runs SHACL validation with the TopBraid CLI
+```
+
+The Go workflow downloads binaries into `build/tools/` and reuses the same fixtures and output locations as the Python scripts, allowing both approaches to coexist.
+
 ## Supporting datasets
 
 New fixtures unlock automation reuse across modules:

--- a/cmd/bhashctl/main.go
+++ b/cmd/bhashctl/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hashgraph/bhash/internal/tools"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "install":
+		runInstall(os.Args[2:])
+	case "shacl":
+		runShacl(os.Args[2:])
+	case "sparql":
+		runSparql(os.Args[2:])
+	default:
+		usage()
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Usage: %s <install|shacl|sparql> [options]\n", filepath.Base(os.Args[0]))
+}
+
+func runInstall(args []string) {
+	fs := flag.NewFlagSet("install", flag.ExitOnError)
+	robotVersion := fs.String("robot-version", tools.DefaultRobotVersion, "ROBOT version to install")
+	shaclVersion := fs.String("shacl-version", tools.DefaultShaclVersion, "TopBraid SHACL distribution version")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	cfg := loadConfig()
+	cfg.RobotVersion = *robotVersion
+	cfg.ShaclVersion = *shaclVersion
+
+	if err := tools.InstallRobot(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "install robot: %v\n", err)
+		os.Exit(1)
+	}
+	if err := tools.InstallShacl(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "install shacl: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runShacl(args []string) {
+	fs := flag.NewFlagSet("shacl", flag.ExitOnError)
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	cfg := loadConfig()
+	if err := tools.RunShacl(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runSparql(args []string) {
+	fs := flag.NewFlagSet("sparql", flag.ExitOnError)
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	cfg := loadConfig()
+	if err := tools.RunSparql(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func loadConfig() *tools.Config {
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "determine cwd: %v\n", err)
+		os.Exit(1)
+	}
+	root, err := tools.FindRepoRoot(cwd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "locate repo root: %v\n", err)
+		os.Exit(1)
+	}
+	return tools.NewConfig(root)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashgraph/bhash
+
+go 1.22

--- a/internal/tools/archive.go
+++ b/internal/tools/archive.go
@@ -1,0 +1,56 @@
+package tools
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func unzip(src, dest string) error {
+	reader, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	for _, file := range reader.File {
+		targetPath := filepath.Join(dest, file.Name)
+		if !strings.HasPrefix(targetPath, filepath.Clean(dest)+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path %s", targetPath)
+		}
+
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(targetPath, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return err
+		}
+
+		rc, err := file.Open()
+		if err != nil {
+			return err
+		}
+
+		out, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		if err != nil {
+			rc.Close()
+			return err
+		}
+
+		if _, err := io.Copy(out, rc); err != nil {
+			out.Close()
+			rc.Close()
+			return err
+		}
+		out.Close()
+		rc.Close()
+	}
+	return nil
+}

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -1,0 +1,77 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	DefaultRobotVersion = "1.9.5"
+	DefaultShaclVersion = "1.4.3"
+)
+
+type Config struct {
+	RepoRoot     string
+	BuildDir     string
+	ToolsDir     string
+	BinDir       string
+	RobotVersion string
+	ShaclVersion string
+}
+
+func NewConfig(repoRoot string) *Config {
+	buildDir := filepath.Join(repoRoot, "build")
+	toolsDir := filepath.Join(buildDir, "tools")
+	binDir := filepath.Join(toolsDir, "bin")
+	return &Config{
+		RepoRoot:     repoRoot,
+		BuildDir:     buildDir,
+		ToolsDir:     toolsDir,
+		BinDir:       binDir,
+		RobotVersion: DefaultRobotVersion,
+		ShaclVersion: DefaultShaclVersion,
+	}
+}
+
+func (c *Config) RobotJarPath() string {
+	return filepath.Join(c.ToolsDir, "robot", "robot.jar")
+}
+
+func (c *Config) RobotExecutable() string {
+	return filepath.Join(c.BinDir, "robot")
+}
+
+func (c *Config) RobotDownloadURL() string {
+	return fmt.Sprintf("https://github.com/ontodev/robot/releases/download/v%[1]s/robot.jar", c.RobotVersion)
+}
+
+func (c *Config) ShaclArchivePath() string {
+	return filepath.Join(c.ToolsDir, "downloads", fmt.Sprintf("shacl-%s-bin.zip", c.ShaclVersion))
+}
+
+func (c *Config) ShaclDownloadURL() string {
+	return fmt.Sprintf("https://repo1.maven.org/maven2/org/topbraid/shacl/%[1]s/shacl-%[1]s-bin.zip", c.ShaclVersion)
+}
+
+func (c *Config) ShaclInstallDir() string {
+	return filepath.Join(c.ToolsDir, "shacl")
+}
+
+func (c *Config) ShaclVersionDir() string {
+	return filepath.Join(c.ShaclInstallDir(), fmt.Sprintf("shacl-%s", c.ShaclVersion))
+}
+
+func (c *Config) ShaclValidateScript() string {
+	return filepath.Join(c.BinDir, "shaclvalidate")
+}
+
+func (c *Config) EnsureBaseDirs() error {
+	dirs := []string{c.BuildDir, c.ToolsDir, c.BinDir, filepath.Join(c.ToolsDir, "robot"), filepath.Join(c.ToolsDir, "downloads")}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/tools/data.go
+++ b/internal/tools/data.go
@@ -1,0 +1,92 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+func (c *Config) datasetPaths() ([]string, error) {
+	base := []string{
+		filepath.Join(c.RepoRoot, "ontology", "examples", "core-consensus.ttl"),
+		filepath.Join(c.RepoRoot, "ontology", "examples", "token-compliance.ttl"),
+		filepath.Join(c.RepoRoot, "ontology", "examples", "smart-contracts.ttl"),
+		filepath.Join(c.RepoRoot, "ontology", "examples", "file-schedule.ttl"),
+		filepath.Join(c.RepoRoot, "ontology", "examples", "mirror-analytics.ttl"),
+		filepath.Join(c.RepoRoot, "ontology", "examples", "hiero.ttl"),
+		filepath.Join(c.RepoRoot, "ontology", "examples", "alignment-esg.ttl"),
+	}
+	fixturesDir := filepath.Join(c.RepoRoot, "tests", "fixtures", "datasets")
+	entries, err := os.ReadDir(fixturesDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) == ".ttl" {
+			base = append(base, filepath.Join(fixturesDir, entry.Name()))
+		}
+	}
+	if len(base) > 7 {
+		sort.Strings(base[7:])
+	}
+	return existingFiles(base), nil
+}
+
+func (c *Config) shapePaths() ([]string, error) {
+	shapesDir := filepath.Join(c.RepoRoot, "ontology", "shapes")
+	entries, err := os.ReadDir(shapesDir)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) == ".ttl" {
+			paths = append(paths, filepath.Join(shapesDir, entry.Name()))
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func (c *Config) queryPaths() ([]string, error) {
+	queriesDir := filepath.Join(c.RepoRoot, "tests", "queries")
+	entries, err := os.ReadDir(queriesDir)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) == ".rq" {
+			paths = append(paths, filepath.Join(queriesDir, entry.Name()))
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func existingFiles(paths []string) []string {
+	filtered := paths[:0]
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			filtered = append(filtered, path)
+		}
+	}
+	return filtered
+}
+
+func ensureNonEmpty(paths []string, label string) error {
+	if len(paths) == 0 {
+		return fmt.Errorf("no %s files located", label)
+	}
+	return nil
+}

--- a/internal/tools/download.go
+++ b/internal/tools/download.go
@@ -1,0 +1,43 @@
+package tools
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+func downloadFile(url, dest string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: unexpected status %s", url, resp.Status)
+	}
+
+	tmp, err := os.CreateTemp("", "bhash-download-*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		tmp.Close()
+		os.Remove(tmp.Name())
+	}()
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		return err
+	}
+
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp.Name(), dest)
+}

--- a/internal/tools/env.go
+++ b/internal/tools/env.go
@@ -1,0 +1,24 @@
+package tools
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func FindRepoRoot(start string) (string, error) {
+	dir := start
+	for {
+		if dir == "" || dir == string(filepath.Separator) {
+			return "", errors.New("could not locate repository root")
+		}
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("could not locate repository root")
+		}
+		dir = parent
+	}
+}

--- a/internal/tools/install.go
+++ b/internal/tools/install.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func InstallRobot(cfg *Config) error {
+	if err := cfg.EnsureBaseDirs(); err != nil {
+		return err
+	}
+	jarPath := cfg.RobotJarPath()
+	if _, err := os.Stat(jarPath); os.IsNotExist(err) {
+		if err := downloadFile(cfg.RobotDownloadURL(), jarPath); err != nil {
+			return err
+		}
+	}
+	wrapper := cfg.RobotExecutable()
+	if err := writeScript(wrapper, fmt.Sprintf("#!/usr/bin/env bash\nexec java -jar '%s' \"$@\"\n", jarPath)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func InstallShacl(cfg *Config) error {
+	if err := cfg.EnsureBaseDirs(); err != nil {
+		return err
+	}
+
+	versionDir := cfg.ShaclVersionDir()
+	if _, err := os.Stat(versionDir); os.IsNotExist(err) {
+		archivePath := cfg.ShaclArchivePath()
+		if _, err := os.Stat(archivePath); os.IsNotExist(err) {
+			if err := downloadFile(cfg.ShaclDownloadURL(), archivePath); err != nil {
+				return err
+			}
+		}
+		if err := unzip(archivePath, cfg.ShaclInstallDir()); err != nil {
+			return err
+		}
+	}
+
+	scriptSrc := filepath.Join(versionDir, "bin", "shaclvalidate.sh")
+	if err := os.Chmod(scriptSrc, 0o755); err != nil && !os.IsPermission(err) {
+		return err
+	}
+
+	wrapper := cfg.ShaclValidateScript()
+	script := fmt.Sprintf("#!/usr/bin/env bash\n'%s' \"$@\"\n", scriptSrc)
+	if err := writeScript(wrapper, script); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeScript(path, contents string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/tools/robot.go
+++ b/internal/tools/robot.go
@@ -1,0 +1,80 @@
+package tools
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func mergeWithRobot(robot string, inputs []string, output string) error {
+	if len(inputs) == 0 {
+		return fmt.Errorf("merge: no input files provided")
+	}
+	args := []string{"merge"}
+	for _, path := range inputs {
+		args = append(args, "--input", path)
+	}
+	args = append(args, "--output", output)
+
+	cmd := exec.Command(robot, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("robot merge: %w", err)
+	}
+	return nil
+}
+
+func runRobotQuery(robot, dataFile, queryFile, outputFile string) error {
+	if err := os.MkdirAll(filepath.Dir(outputFile), 0o755); err != nil {
+		return err
+	}
+	args := []string{"query", "--input", dataFile, "--query", queryFile, outputFile}
+	cmd := exec.Command(robot, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("robot query (%s): %w", filepath.Base(queryFile), err)
+	}
+	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+		header, err := extractSelectHeader(queryFile)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(outputFile, []byte(header+"\n"), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractSelectHeader(queryFile string) (string, error) {
+	data, err := os.ReadFile(queryFile)
+	if err != nil {
+		return "", err
+	}
+	lower := bytes.ToLower(data)
+	idx := bytes.Index(lower, []byte("select"))
+	if idx == -1 {
+		return "", fmt.Errorf("query %s: unable to infer header", queryFile)
+	}
+	fragment := lower[idx:]
+	end := bytes.IndexByte(fragment, '{')
+	if end == -1 {
+		end = len(fragment)
+	}
+	fields := bytes.Fields(fragment[:end])
+	var vars []string
+	for _, field := range fields[1:] {
+		if len(field) > 0 && field[0] == '?' {
+			vars = append(vars, string(field[1:]))
+		}
+	}
+	if len(vars) == 0 {
+		return "", fmt.Errorf("query %s: unable to infer header", queryFile)
+	}
+	return strings.Join(vars, ","), nil
+}

--- a/internal/tools/shacl.go
+++ b/internal/tools/shacl.go
@@ -1,0 +1,71 @@
+package tools
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func RunShacl(cfg *Config) error {
+	datasets, err := cfg.datasetPaths()
+	if err != nil {
+		return err
+	}
+	if err := ensureNonEmpty(datasets, "dataset"); err != nil {
+		return err
+	}
+	shapes, err := cfg.shapePaths()
+	if err != nil {
+		return err
+	}
+	if err := ensureNonEmpty(shapes, "shape"); err != nil {
+		return err
+	}
+
+	tempDir, err := os.MkdirTemp(cfg.BuildDir, "shacl-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	dataFile := filepath.Join(tempDir, "data.ttl")
+	if err := mergeWithRobot(cfg.RobotExecutable(), datasets, dataFile); err != nil {
+		return err
+	}
+
+	shapesFile := filepath.Join(tempDir, "shapes.ttl")
+	if err := mergeWithRobot(cfg.RobotExecutable(), shapes, shapesFile); err != nil {
+		return err
+	}
+
+	reportDir := filepath.Join(cfg.BuildDir, "reports")
+	if err := os.MkdirAll(reportDir, 0o755); err != nil {
+		return err
+	}
+	reportPath := filepath.Join(reportDir, "shacl-report.ttl")
+
+	cmd := exec.Command(cfg.ShaclValidateScript(), "-datafile", dataFile, "-shapesfile", shapesFile)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	output := stdout.Bytes()
+	fmt.Print(string(output))
+
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if writeErr := os.WriteFile(reportPath, output, 0o644); writeErr != nil {
+				return fmt.Errorf("shacl validation failed: %v (additional error writing report: %w)", exitErr, writeErr)
+			}
+			return fmt.Errorf("shacl validation failed; report written to %s", reportPath)
+		}
+		return err
+	}
+
+	if _, err := os.Stat(reportPath); err == nil {
+		os.Remove(reportPath)
+	}
+	return nil
+}

--- a/internal/tools/sparql.go
+++ b/internal/tools/sparql.go
@@ -1,0 +1,130 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func RunSparql(cfg *Config) error {
+	datasets, err := cfg.datasetPaths()
+	if err != nil {
+		return err
+	}
+	if err := ensureNonEmpty(datasets, "dataset"); err != nil {
+		return err
+	}
+
+	queries, err := cfg.queryPaths()
+	if err != nil {
+		return err
+	}
+	if err := ensureNonEmpty(queries, "query"); err != nil {
+		return err
+	}
+
+	tempDir, err := os.MkdirTemp(cfg.BuildDir, "sparql-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	dataFile := filepath.Join(tempDir, "data.ttl")
+	if err := mergeWithRobot(cfg.RobotExecutable(), datasets, dataFile); err != nil {
+		return err
+	}
+
+	outputDir := filepath.Join(cfg.BuildDir, "queries")
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return err
+	}
+
+	resultsDir := filepath.Join(cfg.RepoRoot, "tests", "fixtures", "results")
+	success := true
+	var failures []string
+
+	for _, query := range queries {
+		name := filepath.Base(query)
+		fmt.Printf("Running %s...\n", name)
+		output := filepath.Join(outputDir, strings.TrimSuffix(name, filepath.Ext(name))+".csv")
+		if err := runRobotQuery(cfg.RobotExecutable(), dataFile, query, output); err != nil {
+			return err
+		}
+		expected := filepath.Join(resultsDir, filepath.Base(output))
+		match, err := compareCSV(expected, output)
+		if err != nil {
+			return err
+		}
+		if !match {
+			success = false
+			failures = append(failures, name)
+		}
+	}
+
+	if !success {
+		return fmt.Errorf("sparql regression failures: %s", strings.Join(failures, ", "))
+	}
+	return nil
+}
+
+func compareCSV(expectedPath, actualPath string) (bool, error) {
+	expected, err := readCSVLines(expectedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("No expected results for %s; skipping comparison.\n", filepath.Base(actualPath))
+			return true, nil
+		}
+		return false, err
+	}
+	actual, err := readCSVLines(actualPath)
+	if err != nil {
+		return false, err
+	}
+	if len(expected) != len(actual) {
+		printCSVDelta(expected, actual)
+		return false, nil
+	}
+	for i := range expected {
+		if expected[i] != actual[i] {
+			printCSVDelta(expected, actual)
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func readCSVLines(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(data), "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			filtered = append(filtered, normalizeCSVLine(trimmed))
+		}
+	}
+	return filtered, nil
+}
+
+func printCSVDelta(expected, actual []string) {
+	fmt.Println("Expected:")
+	for _, line := range expected {
+		fmt.Printf("  %s\n", line)
+	}
+	fmt.Println("Actual:")
+	for _, line := range actual {
+		fmt.Printf("  %s\n", line)
+	}
+}
+
+func normalizeCSVLine(line string) string {
+	// Normalise time zone suffixes so that "Z" and "+00:00" compare equal.
+	line = strings.ReplaceAll(line, "+00:00", "Z")
+	// ROBOT may produce "-00:00" for unknown offsets; keep consistent with fixtures.
+	line = strings.ReplaceAll(line, "-00:00", "Z")
+	return line
+}


### PR DESCRIPTION
## Summary
- add a Go-based CLI (`cmd/bhashctl`) that installs ROBOT and the TopBraid SHACL CLI into build/tools
- implement helpers to merge datasets, execute SPARQL regression queries with ROBOT, and validate SHACL shapes via the TopBraid CLI
- document the Go workflow alongside the existing Python scripts in the README

## Testing
- go build ./...
- go run ./cmd/bhashctl install
- go run ./cmd/bhashctl sparql
- go run ./cmd/bhashctl shacl

------
https://chatgpt.com/codex/tasks/task_b_68cadb9b076483238cba2a714d578a0a