### PR TITLE
feat: add Go Fluree client and CLI replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,15 @@ All four modules reuse the same prefixes (`ontology/src/alignment/prefixes.ttl`)
 
 ## Running validation
 
-Use the Go-based CLI to install validation tooling and execute regression checks. The
-commands below download the required binaries on demand and materialise results under
-`build/` (created automatically):
+Use the Go-based CLI to install validation tooling, interact with Fluree datasets, and
+execute regression checks. The commands below download the required binaries on demand
+and materialise results under `build/` (created automatically):
 
 ```bash
-go run ./cmd/bhashctl install  # Fetch ROBOT + TopBraid SHACL into build/tools
-go run ./cmd/bhashctl sparql   # Execute SPARQL regression queries via ROBOT
-go run ./cmd/bhashctl shacl    # Run SHACL validation with the TopBraid CLI
+go run ./cmd/bhashctl install          # Fetch ROBOT + TopBraid SHACL into build/tools
+go run ./cmd/bhashctl sparql           # Execute SPARQL regression queries via ROBOT
+go run ./cmd/bhashctl shacl            # Run SHACL validation with the TopBraid CLI
+go run ./cmd/bhashctl fluree transact  # Apply JSON-LD transactions to a Fluree ledger
 ```
 
 The CLI reuses the repository fixtures and reports mismatches against expected

--- a/cmd/bhashctl/main.go
+++ b/cmd/bhashctl/main.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
+	"github.com/hashgraph/bhash/internal/fluree"
 	"github.com/hashgraph/bhash/internal/tools"
 )
 
@@ -22,6 +28,8 @@ func main() {
 		runShacl(os.Args[2:])
 	case "sparql":
 		runSparql(os.Args[2:])
+	case "fluree":
+		runFluree(os.Args[2:])
 	default:
 		usage()
 		os.Exit(1)
@@ -29,7 +37,7 @@ func main() {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "Usage: %s <install|shacl|sparql> [options]\n", filepath.Base(os.Args[0]))
+	fmt.Fprintf(os.Stderr, "Usage: %s <install|shacl|sparql|fluree> [options]\n", filepath.Base(os.Args[0]))
 }
 
 func runInstall(args []string) {
@@ -79,6 +87,259 @@ func runSparql(args []string) {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
+}
+
+func runFluree(args []string) {
+	if len(args) == 0 {
+		flureeUsage()
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "create-dataset":
+		runFlureeCreateDataset(args[1:])
+	case "transact":
+		runFlureeTransact(args[1:])
+	case "generate-sparql":
+		runFlureeGenerate(args[1:], "generate-sparql")
+	case "generate-answer":
+		runFlureeGenerate(args[1:], "generate-answer")
+	case "generate-prompt":
+		runFlureeGenerate(args[1:], "generate-prompt")
+	default:
+		flureeUsage()
+		os.Exit(1)
+	}
+}
+
+func flureeUsage() {
+	fmt.Fprintf(os.Stderr, "Usage: %s fluree <create-dataset|transact|generate-sparql|generate-answer|generate-prompt> [options]\n", filepath.Base(os.Args[0]))
+}
+
+func runFlureeCreateDataset(args []string) {
+	fs := flag.NewFlagSet("fluree create-dataset", flag.ExitOnError)
+	apiToken := fs.String("api-token", "", "Fluree API token (defaults to $FLUREE_API_TOKEN)")
+	tenant := fs.String("tenant", "", "Fluree tenant handle (defaults to $FLUREE_HANDLE)")
+	baseURL := fs.String("base-url", "", "Fluree API base URL (defaults to $FLUREE_BASE_URL)")
+	owner := fs.String("owner", "", "Owner handle responsible for the dataset")
+	datasetName := fs.String("dataset-name", "", "Dataset name")
+	storageType := fs.String("storage-type", "sparql", "Storage type")
+	description := fs.String("description", "", "Dataset description")
+	visibility := fs.String("visibility", "private", "Dataset visibility")
+	tags := newStringSliceFlag()
+	fs.Var(tags, "tag", "Tag to apply to the dataset (may be repeated)")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	cfg := mustFlureeConfig(*apiToken, *tenant, *baseURL)
+	if *owner == "" || *datasetName == "" || *description == "" {
+		fmt.Fprintln(os.Stderr, "owner, dataset-name, and description are required")
+		os.Exit(1)
+	}
+
+	client := fluree.NewClient(cfg, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result, err := client.CreateDataset(ctx, *owner, fluree.CreateDatasetRequest{
+		DatasetName: *datasetName,
+		StorageType: *storageType,
+		Description: *description,
+		Visibility:  *visibility,
+		Tags:        tags.Values(),
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	printJSON(result)
+}
+
+func runFlureeTransact(args []string) {
+	fs := flag.NewFlagSet("fluree transact", flag.ExitOnError)
+	apiToken := fs.String("api-token", "", "Fluree API token (defaults to $FLUREE_API_TOKEN)")
+	tenant := fs.String("tenant", "", "Fluree tenant handle (defaults to $FLUREE_HANDLE)")
+	baseURL := fs.String("base-url", "", "Fluree API base URL (defaults to $FLUREE_BASE_URL)")
+	ledger := fs.String("ledger", "", "Ledger identifier")
+	insertPath := fs.String("insert", "", "Path to JSON file containing an array of insert statements")
+	deletePath := fs.String("delete", "", "Path to JSON file containing an array of delete statements")
+	wherePath := fs.String("where", "", "Path to JSON file containing a where clause array")
+	contextPath := fs.String("context", "", "Path to JSON file containing a JSON-LD context object")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	cfg := mustFlureeConfig(*apiToken, *tenant, *baseURL)
+	if strings.TrimSpace(*ledger) == "" {
+		fmt.Fprintln(os.Stderr, "ledger is required")
+		os.Exit(1)
+	}
+
+	req := fluree.TransactionRequest{Ledger: *ledger}
+	if *insertPath != "" {
+		values, err := loadJSONArrayMap(*insertPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "load insert payload: %v\n", err)
+			os.Exit(1)
+		}
+		req.Insert = values
+	}
+	if *deletePath != "" {
+		values, err := loadJSONArrayMap(*deletePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "load delete payload: %v\n", err)
+			os.Exit(1)
+		}
+		req.Delete = values
+	}
+	if *wherePath != "" {
+		values, err := loadJSONArrayMap(*wherePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "load where payload: %v\n", err)
+			os.Exit(1)
+		}
+		req.Where = values
+	}
+	if *contextPath != "" {
+		value, err := loadJSONMap(*contextPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "load context payload: %v\n", err)
+			os.Exit(1)
+		}
+		req.Context = value
+	}
+
+	client := fluree.NewClient(cfg, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result, err := client.Transact(ctx, req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	printJSON(result)
+}
+
+func runFlureeGenerate(args []string, endpoint string) {
+	fs := flag.NewFlagSet("fluree "+endpoint, flag.ExitOnError)
+	apiToken := fs.String("api-token", "", "Fluree API token (defaults to $FLUREE_API_TOKEN)")
+	tenant := fs.String("tenant", "", "Fluree tenant handle (defaults to $FLUREE_HANDLE)")
+	baseURL := fs.String("base-url", "", "Fluree API base URL (defaults to $FLUREE_BASE_URL)")
+	owner := fs.String("owner", "", "Owner handle responsible for the datasets")
+	prompt := fs.String("prompt", "", "Prompt/question to send to Fluree")
+	datasets := newStringSliceFlag()
+	fs.Var(datasets, "dataset", "Dataset identifier to include (may be repeated)")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	cfg := mustFlureeConfig(*apiToken, *tenant, *baseURL)
+	if *owner == "" || *prompt == "" {
+		fmt.Fprintln(os.Stderr, "owner and prompt are required")
+		os.Exit(1)
+	}
+
+	request := fluree.PromptRequest{Datasets: datasets.Values(), Prompt: *prompt}
+	client := fluree.NewClient(cfg, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	var (
+		result any
+		err    error
+	)
+	switch endpoint {
+	case "generate-sparql":
+		result, err = client.GenerateSPARQL(ctx, *owner, request)
+	case "generate-answer":
+		result, err = client.GenerateAnswer(ctx, *owner, request)
+	case "generate-prompt":
+		result, err = client.GeneratePrompt(ctx, *owner, request)
+	default:
+		err = errors.New("unsupported endpoint")
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	printJSON(result)
+}
+
+func mustFlureeConfig(apiToken, tenant, baseURL string) fluree.Config {
+	cfg, err := fluree.EnvConfigFromLookup(func(key string) (string, bool) {
+		value, ok := os.LookupEnv(key)
+		return value, ok
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	cfg = cfg.WithOverrides(apiToken, tenant, baseURL)
+	if err := cfg.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	return cfg
+}
+
+func loadJSONArrayMap(path string) ([]map[string]any, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	var payload []map[string]any
+	if err := json.NewDecoder(file).Decode(&payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func loadJSONMap(path string) (map[string]any, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	payload := make(map[string]any)
+	if err := json.NewDecoder(file).Decode(&payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func printJSON(value any) {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		fmt.Fprintf(os.Stderr, "encode JSON: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type stringSliceFlag struct {
+	values []string
+}
+
+func newStringSliceFlag() *stringSliceFlag {
+	return &stringSliceFlag{}
+}
+
+func (s *stringSliceFlag) String() string {
+	return strings.Join(s.values, ",")
+}
+
+func (s *stringSliceFlag) Set(value string) error {
+	s.values = append(s.values, value)
+	return nil
+}
+
+func (s *stringSliceFlag) Values() []string {
+	return append([]string(nil), s.values...)
 }
 
 func loadConfig() *tools.Config {

--- a/internal/fluree/client.go
+++ b/internal/fluree/client.go
@@ -1,0 +1,200 @@
+package fluree
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+// Client provides strongly typed helpers for interacting with the Fluree HTTP
+// API.
+type Client struct {
+	httpClient *http.Client
+	config     Config
+}
+
+// NewClient returns a Client configured with the supplied credentials. When
+// httpClient is nil the default http.Client with a 30s timeout is used.
+func NewClient(cfg Config, httpClient *http.Client) *Client {
+	client := httpClient
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &Client{httpClient: client, config: cfg}
+}
+
+// APIError captures the HTTP status code and message returned by Fluree.
+type APIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	if e.Message == "" {
+		return fmt.Sprintf("fluree: unexpected HTTP status %d", e.StatusCode)
+	}
+	return fmt.Sprintf("fluree: %s (status %d)", e.Message, e.StatusCode)
+}
+
+func (c *Client) doPost(ctx context.Context, endpoint string, payload any) (any, error) {
+	base, err := url.Parse(c.config.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("fluree: invalid base URL %q: %w", c.config.BaseURL, err)
+	}
+	base.Path = path.Join(strings.TrimSuffix(base.Path, "/"), endpoint)
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("fluree: encode payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("fluree: build request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.APIToken))
+	req.Header.Set("x-user-handle", c.config.TenantHandle)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fluree: perform request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("fluree: read response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, &APIError{StatusCode: resp.StatusCode, Message: parseErrorMessage(data, resp.Status)}
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var decoded any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return string(data), nil
+	}
+	return decoded, nil
+}
+
+func parseErrorMessage(data []byte, fallback string) string {
+	var decoded any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return fallback
+	}
+	switch v := decoded.(type) {
+	case map[string]any:
+		if msg, ok := v["message"].(string); ok && msg != "" {
+			return msg
+		}
+		if msg, ok := v["error"].(string); ok && msg != "" {
+			return msg
+		}
+		return fmt.Sprint(v)
+	case string:
+		return v
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+// CreateDatasetRequest describes the payload sent to the create-dataset endpoint.
+type CreateDatasetRequest struct {
+	DatasetName string
+	StorageType string
+	Description string
+	Visibility  string
+	Tags        []string
+}
+
+// CreateDataset creates a dataset owned by the provided Fluree handle.
+func (c *Client) CreateDataset(ctx context.Context, ownerHandle string, req CreateDatasetRequest) (any, error) {
+	if ownerHandle == "" {
+		return nil, fmt.Errorf("fluree: owner handle is required")
+	}
+	payload := map[string]any{
+		"datasetName": req.DatasetName,
+		"storageType": req.StorageType,
+		"description": req.Description,
+	}
+	if req.Visibility != "" {
+		payload["visibility"] = req.Visibility
+	}
+	if len(req.Tags) > 0 {
+		payload["tags"] = req.Tags
+	}
+	endpoint := path.Join("api", ownerHandle, "create-dataset")
+	return c.doPost(ctx, endpoint, payload)
+}
+
+// TransactionRequest represents the payload for a Fluree transact request.
+type TransactionRequest struct {
+	Ledger  string
+	Insert  []map[string]any
+	Delete  []map[string]any
+	Where   []map[string]any
+	Context map[string]any
+}
+
+// Transact executes a ledger transaction.
+func (c *Client) Transact(ctx context.Context, req TransactionRequest) (any, error) {
+	if strings.TrimSpace(req.Ledger) == "" {
+		return nil, fmt.Errorf("fluree: ledger is required")
+	}
+	payload := map[string]any{"ledger": req.Ledger}
+	if req.Context != nil {
+		payload["context"] = req.Context
+	}
+	if len(req.Insert) > 0 {
+		payload["insert"] = req.Insert
+	}
+	if len(req.Delete) > 0 {
+		payload["delete"] = req.Delete
+	}
+	if len(req.Where) > 0 {
+		payload["where"] = req.Where
+	}
+	return c.doPost(ctx, "fluree/transact", payload)
+}
+
+// PromptRequest describes a request that renders natural language responses.
+type PromptRequest struct {
+	Datasets []string
+	Prompt   string
+}
+
+// GeneratePrompt calls the Fluree generate-prompt endpoint.
+func (c *Client) GeneratePrompt(ctx context.Context, ownerHandle string, req PromptRequest) (any, error) {
+	return c.generateHelper(ctx, ownerHandle, "generate-prompt", req)
+}
+
+// GenerateSPARQL calls the Fluree generate-sparql endpoint.
+func (c *Client) GenerateSPARQL(ctx context.Context, ownerHandle string, req PromptRequest) (any, error) {
+	return c.generateHelper(ctx, ownerHandle, "generate-sparql", req)
+}
+
+// GenerateAnswer calls the Fluree generate-answer endpoint.
+func (c *Client) GenerateAnswer(ctx context.Context, ownerHandle string, req PromptRequest) (any, error) {
+	return c.generateHelper(ctx, ownerHandle, "generate-answer", req)
+}
+
+func (c *Client) generateHelper(ctx context.Context, ownerHandle, suffix string, req PromptRequest) (any, error) {
+	if ownerHandle == "" {
+		return nil, fmt.Errorf("fluree: owner handle is required")
+	}
+	payload := map[string]any{
+		"datasets": req.Datasets,
+		"prompt":   req.Prompt,
+	}
+	endpoint := path.Join("api", ownerHandle, suffix)
+	return c.doPost(ctx, endpoint, payload)
+}

--- a/internal/fluree/client_test.go
+++ b/internal/fluree/client_test.go
@@ -1,0 +1,104 @@
+package fluree
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateDataset(t *testing.T) {
+	var received map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/owner/create-dataset" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Fatalf("unexpected Authorization header %q", got)
+		}
+		if got := r.Header.Get("x-user-handle"); got != "tenant" {
+			t.Fatalf("unexpected tenant header %q", got)
+		}
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{APIToken: "token", TenantHandle: "tenant", BaseURL: server.URL}
+	client := NewClient(cfg, server.Client())
+	resp, err := client.CreateDataset(context.Background(), "owner", CreateDatasetRequest{
+		DatasetName: "example",
+		StorageType: "sparql",
+		Description: "demo",
+		Visibility:  "private",
+		Tags:        []string{"alpha"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if received["datasetName"] != "example" || received["visibility"] != "private" {
+		t.Fatalf("unexpected payload %+v", received)
+	}
+	data, ok := resp.(map[string]any)
+	if !ok || data["ok"].(bool) != true {
+		t.Fatalf("unexpected response %#v", resp)
+	}
+}
+
+func TestTransactError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"message":"boom"}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{APIToken: "token", TenantHandle: "tenant", BaseURL: server.URL}
+	client := NewClient(cfg, server.Client())
+	_, err := client.Transact(context.Background(), TransactionRequest{Ledger: "ledger"})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.Message != "boom" {
+		t.Fatalf("unexpected message %q", apiErr.Message)
+	}
+}
+
+func TestGenerateAnswer(t *testing.T) {
+	var received map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/owner/generate-answer" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		defer r.Body.Close()
+		json.NewDecoder(r.Body).Decode(&received)
+		w.Write([]byte(`{"answer":"42"}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{APIToken: "token", TenantHandle: "tenant", BaseURL: server.URL}
+	client := NewClient(cfg, server.Client())
+	resp, err := client.GenerateAnswer(context.Background(), "owner", PromptRequest{
+		Datasets: []string{"a", "b"},
+		Prompt:   "question",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if received["prompt"] != "question" {
+		t.Fatalf("unexpected payload %#v", received)
+	}
+	data := resp.(map[string]any)
+	if data["answer"].(string) != "42" {
+		t.Fatalf("unexpected response %#v", data)
+	}
+}

--- a/internal/fluree/config.go
+++ b/internal/fluree/config.go
@@ -1,0 +1,69 @@
+package fluree
+
+import (
+	"fmt"
+	"strings"
+)
+
+const defaultBaseURL = "https://data.flur.ee"
+
+// Config contains the credentials and endpoint information required to talk
+// to the Fluree Cloud API.
+type Config struct {
+	APIToken     string
+	TenantHandle string
+	BaseURL      string
+}
+
+// EnvConfigFromLookup builds a Config using the provided lookup function.
+// The lookup function typically wraps os.LookupEnv.
+func EnvConfigFromLookup(lookup func(string) (string, bool)) (Config, error) {
+	cfg := Config{BaseURL: defaultBaseURL}
+	if v, ok := lookup("FLUREE_API_TOKEN"); ok {
+		cfg.APIToken = strings.TrimSpace(v)
+	}
+	if v, ok := lookup("FLUREE_HANDLE"); ok {
+		cfg.TenantHandle = strings.TrimSpace(v)
+	}
+	if v, ok := lookup("FLUREE_BASE_URL"); ok && strings.TrimSpace(v) != "" {
+		cfg.BaseURL = strings.TrimRight(strings.TrimSpace(v), "/")
+	}
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// Validate ensures the configuration is complete.
+func (c Config) Validate() error {
+	var missing []string
+	if c.APIToken == "" {
+		missing = append(missing, "FLUREE_API_TOKEN")
+	}
+	if c.TenantHandle == "" {
+		missing = append(missing, "FLUREE_HANDLE")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing environment variables: %s", strings.Join(missing, ", "))
+	}
+	if c.BaseURL == "" {
+		return fmt.Errorf("Fluree base URL cannot be empty")
+	}
+	return nil
+}
+
+// WithOverrides returns a copy of the configuration with optional overrides
+// applied. Empty override values are ignored.
+func (c Config) WithOverrides(apiToken, tenant, baseURL string) Config {
+	clone := c
+	if strings.TrimSpace(apiToken) != "" {
+		clone.APIToken = strings.TrimSpace(apiToken)
+	}
+	if strings.TrimSpace(tenant) != "" {
+		clone.TenantHandle = strings.TrimSpace(tenant)
+	}
+	if strings.TrimSpace(baseURL) != "" {
+		clone.BaseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	}
+	return clone
+}

--- a/internal/fluree/config_test.go
+++ b/internal/fluree/config_test.go
@@ -1,0 +1,64 @@
+package fluree
+
+import "testing"
+
+type mapLookup map[string]string
+
+func (m mapLookup) Lookup(key string) (string, bool) {
+	v, ok := m[key]
+	return v, ok
+}
+
+func TestEnvConfigFromLookup(t *testing.T) {
+	cfg, err := EnvConfigFromLookup(mapLookup{
+		"FLUREE_API_TOKEN": " token\t",
+		"FLUREE_HANDLE":    " tenant ",
+	}.Lookup)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.APIToken != "token" {
+		t.Fatalf("expected API token to be trimmed, got %q", cfg.APIToken)
+	}
+	if cfg.TenantHandle != "tenant" {
+		t.Fatalf("expected tenant to be trimmed, got %q", cfg.TenantHandle)
+	}
+	if cfg.BaseURL != defaultBaseURL {
+		t.Fatalf("expected default base URL, got %q", cfg.BaseURL)
+	}
+}
+
+func TestEnvConfigFromLookup_WithBaseURL(t *testing.T) {
+	cfg, err := EnvConfigFromLookup(mapLookup{
+		"FLUREE_API_TOKEN": "token",
+		"FLUREE_HANDLE":    "tenant",
+		"FLUREE_BASE_URL":  " https://example.com/api/ ",
+	}.Lookup)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "https://example.com/api"
+	if cfg.BaseURL != expected {
+		t.Fatalf("expected %q, got %q", expected, cfg.BaseURL)
+	}
+}
+
+func TestEnvConfigFromLookup_Missing(t *testing.T) {
+	if _, err := EnvConfigFromLookup(mapLookup{}.Lookup); err == nil {
+		t.Fatalf("expected error for missing values")
+	}
+}
+
+func TestWithOverrides(t *testing.T) {
+	cfg := Config{APIToken: "a", TenantHandle: "b", BaseURL: "https://example"}
+	updated := cfg.WithOverrides("", " tenant", "https://override/")
+	if updated.APIToken != "a" {
+		t.Fatalf("unexpected API token %q", updated.APIToken)
+	}
+	if updated.TenantHandle != "tenant" {
+		t.Fatalf("unexpected tenant %q", updated.TenantHandle)
+	}
+	if updated.BaseURL != "https://override" {
+		t.Fatalf("unexpected base URL %q", updated.BaseURL)
+	}
+}


### PR DESCRIPTION
## Summary
- replace the Python Fluree helper with a typed Go client under internal/fluree
- expose dataset, transaction, and assistant workflows through new `bhashctl fluree` subcommands
- update documentation to describe the new CLI workflows and current migration status

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68cb0b69be008323b3d6d4602c60c458