### PR TITLE
Ensure deployed ontologies owned by web user

### DIFF
--- a/ontology/scripts/deploy_to_nginx.sh
+++ b/ontology/scripts/deploy_to_nginx.sh
@@ -9,6 +9,8 @@ TARGET_ROOT=${TARGET_ROOT:-/var/www}
 DEST="$TARGET_ROOT/$SITE_NAME/"
 USE_SUDO=${USE_SUDO:-true}
 RSYNC_BIN=${RSYNC_BIN:-rsync}
+WEB_USER=${WEB_USER:-www-data}
+WEB_GROUP=${WEB_GROUP:-www-data}
 
 if [ ! -d "$DEPLOYMENT_DIR" ]; then
     echo "❌ Deployment directory not found: $DEPLOYMENT_DIR" >&2
@@ -23,3 +25,4 @@ fi
 
 set -x
 "${SUDO_CMD[@]}" "$RSYNC_BIN" -av --delete "$DEPLOYMENT_DIR"/ "$DEST"
+"${SUDO_CMD[@]}" chown -R "$WEB_USER":"$WEB_GROUP" "$DEST"


### PR DESCRIPTION
## Summary
- allow configuring target web user and group for deployed ontology files
- ensure files synced to the nginx root are chowned to the web user to avoid root-owned permissions issues

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693159eb7ed48323adf0f466c82fc97c)