### PR TITLE
Document ontology dependency installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,46 @@ snapshots. A handful of legacy Python harnesses remain under `scripts/` while
 their Go replacements are scheduled, but new automation should target the Go
 workflow.
 
+## Generating OWL/HTML/JSON-LD artefacts
+
+Publishable artefacts for each ontology module (OWL/RDF/XML, HTML catalogue,
+JSON-LD, and Turtle) are generated from the source `.ttl` files under
+`ontology/src` via a small Python helper. The script renders human-readable
+catalogues using Jinja2 and keeps machine-readable formats in sync for
+deployments.
+
+1. Prepare the Python environment using the helper script under `ontology/` (this creates `ontology/venv` with the required
+   dependencies):
+
+   ```bash
+   ontology/install_requirements.sh
+   ```
+
+2. Convert the source ontologies into deployable artefacts:
+
+   ```bash
+   ontology/venv/bin/python ontology/scripts/convert_ontologies.py \
+     --source-dir ontology/src \
+     --deployment-dir ontology/deployment
+   ```
+
+   Each module gains four files in `ontology/deployment/`: `.owl` (RDF/XML),
+   `.html` (rendered catalogue), `.jsonld` (JSON-LD context/graph), and `.ttl`
+   (normalised Turtle). A shared `imports/` directory is also refreshed to keep
+   imported slices aligned.
+
+3. Deploy by syncing the `ontology/deployment/` directory to your hosting
+   target (e.g., GitHub Pages, S3 bucket, or an internal web server). For a
+   static publish you can simply run:
+
+   ```bash
+   rsync -avh ontology/deployment/ <user>@<host>:/var/www/ontology/
+   ```
+
+   Downstream systems that consume the OWL or JSON-LD contexts should reference
+   the files from this deployment directory so they stay aligned with the
+   repository sources.
+
 ## Phase 4 data pilot
 
 Run `python scripts/run_phase4_pilot.py` to initialise an Oxigraph-backed triple store with the Phase 3/4 ontologies and example graphs. The script executes the anthropogenic impact competency query, runs SHACL validation, and records artefacts under `build/pilots/phase4/` for stakeholder review. A Go-native pilot command is on the roadmap; see `docs/python_helper_migration_plan.md` for the migration schedule.

--- a/ontology/README.md
+++ b/ontology/README.md
@@ -10,6 +10,19 @@ in the project README and will expand as modelling sprints deliver additional mo
 - `shapes/` – SHACL constraint files that validate RDF data against the ontology (to be populated in later phases).
 - `examples/` – Example graphs, competency question answers, and sample data extracts used for validation.
 
+## Building deployment artefacts
+
+Use the conversion helper to regenerate the deployable OWL (RDF/XML), HTML, JSON-LD, and Turtle files from the sources in
+`src/`. Start by creating the virtual environment via the local installer:
+
+```bash
+./install_requirements.sh
+./venv/bin/python scripts/convert_ontologies.py --source-dir src --deployment-dir deployment
+```
+
+The command emits refreshed artefacts under `deployment/`, including an `imports/` folder for trimmed external dependencies.
+Sync that directory to your publishing target so downstream users pull the latest OWL or JSON-LD contexts.
+
 ## Core module
 
 `src/core.ttl` introduces the upper-level vocabulary shared by all service-specific modules.  Phase 2 expanded the scaffold

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ responses>=0.25.0
 pytest>=7.4.0
 hedera-sdk-py>=2.50.0
 oxrdflib>=0.5.0
+jinja2>=3.1.0


### PR DESCRIPTION
## Summary
- direct ontology artifact generation docs to use ontology/install_requirements.sh before running conversion scripts
- update conversion steps to reference the virtual environment created by the installer

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6931748a903c8323bfff1f82a72d65bf)