### PR TITLE
Represent Hedera instants in their native seconds.nanoseconds form

### DIFF
--- a/docs/mappings/consensus.csv
+++ b/docs/mappings/consensus.csv
@@ -2,7 +2,7 @@ Term,Source Document,Notes
 hedera:ConsensusTopic,https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/topics,Modelled as ordered message channel with admin/submit keys.
 hedera:TopicMessage,https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows,Aligns message metadata with consensus timestamps.
 hedera:hasTopicId,https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/topics,Datatype property capturing the canonical topic ID (shard.realm.num) for a ConsensusTopic; range xsd:string; analogous to hedera:hasAccountId on Account.
-hedera:hasConsensusTimestamp,https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows,Datatype property capturing the consensus-assigned timestamp for a TopicMessage; range xsd:dateTime; subPropertyOf prov:generatedAtTime.
+hedera:hasConsensusTimestamp,https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows,Datatype property capturing the consensus-assigned timestamp for a TopicMessage; range xsd:string in the native Hedera seconds.nanoseconds form; see also prov:generatedAtTime.
 hedera:inTopic,https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows,Object property linking a TopicMessage to the ConsensusTopic it belongs to; domain hedera:TopicMessage; range hedera:ConsensusTopic.
 hedera:RoleAssignment,https://hedera.com/council,Represents committee mandates assigning validator stewardship roles.
 hedera:ValidatorOnboardingSteward,https://hips.hedera.com/hip/hip-840,HIP-840 defines council responsibilities for onboarding validators.

--- a/docs/mappings/file-schedule.csv
+++ b/docs/mappings/file-schedule.csv
@@ -3,4 +3,4 @@ hedera:File,https://docs.hedera.com/hedera/core-concepts/file-service/file-stora
 hedera:FileKey,https://docs.hedera.com/hedera/core-concepts/file-service/file-keys,Key material controlling file updates.
 hedera:PendingSchedule,https://docs.hedera.com/hedera/core-concepts/scheduled-transactions,Represents schedules awaiting additional signatures.
 hedera:hasRequiredSignatureCount,https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work,Tracks total approvals needed before execution.
-hedera:hasScheduleExpiration,https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work,Records expiration timestamp for deferred transactions.
+hedera:hasScheduleExpiration,https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work,Records expiration timestamp for deferred transactions; range xsd:string in the native Hedera seconds.nanoseconds form.

--- a/ontology/deployment/consensus.html
+++ b/ontology/deployment/consensus.html
@@ -52,23 +52,23 @@
             
                 <tr><td>hedera</td><td>https://hashgraphontology.xyz/core/</td></tr>
             
-                <tr><td>ns1</td><td>https://docs.hedera.com/hedera/core-concepts/staking/</td></tr>
+                <tr><td>ns1</td><td>https://hashgraphontology.xyz/</td></tr>
             
-                <tr><td>ns2</td><td>https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/</td></tr>
+                <tr><td>ns2</td><td>https://docs.hedera.com/hedera/core-concepts/governing-the-network#</td></tr>
             
-                <tr><td>ns3</td><td>https://docs.hedera.com/hedera/mirror-node/architecture/</td></tr>
+                <tr><td>ns3</td><td>https://raw.githubusercontent.com/hashgraph/hedera-docs/main/core-concepts/staking/staking.md#</td></tr>
             
-                <tr><td>ns4</td><td>https://hips.hedera.com/hip/</td></tr>
+                <tr><td>ns4</td><td>https://hedera.com/</td></tr>
             
-                <tr><td>ns5</td><td>https://hashgraphontology.xyz/</td></tr>
+                <tr><td>ns5</td><td>https://docs.hedera.com/hedera/core-concepts/</td></tr>
             
-                <tr><td>ns6</td><td>https://docs.hedera.com/hedera/core-concepts/</td></tr>
+                <tr><td>ns6</td><td>https://docs.hedera.com/hedera/mirror-node/architecture/</td></tr>
             
-                <tr><td>ns7</td><td>https://docs.hedera.com/hedera/core-concepts/governing-the-network#</td></tr>
+                <tr><td>ns7</td><td>https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/</td></tr>
             
-                <tr><td>ns8</td><td>https://raw.githubusercontent.com/hashgraph/hedera-docs/main/core-concepts/staking/staking.md#</td></tr>
+                <tr><td>ns8</td><td>https://docs.hedera.com/hedera/core-concepts/staking/</td></tr>
             
-                <tr><td>ns9</td><td>https://hedera.com/</td></tr>
+                <tr><td>ns9</td><td>https://hips.hedera.com/hip/</td></tr>
             
                 <tr><td>owl</td><td>http://www.w3.org/2002/07/owl#</td></tr>
             
@@ -309,10 +309,10 @@
                     <td>hedera:hasConsensusTimestamp</td>
                     <td>DatatypeProperty</td>
                     <td><span class="pill">hedera:TopicMessage</span></td>
-                    <td><span class="pill">xsd:dateTime</span></td>
+                    <td><span class="pill">xsd:string</span></td>
                     <td class="small">
                         
-                        <div><strong>SubProperty Of:</strong> <span class="pill">prov:generatedAtTime</span></div>
+                        
                         
                         <div class="meta">IRI: https://hashgraphontology.xyz/core/hasConsensusTimestamp</div>
                     </td>

--- a/ontology/deployment/consensus.jsonld
+++ b/ontology/deployment/consensus.jsonld
@@ -1,57 +1,170 @@
 [
   {
-    "@id": "https://hashgraphontology.xyz/core/targetsTopic",
+    "@id": "https://hashgraphontology.xyz/core/hasEndpointAddress",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#domain": [
       {
-        "@id": "https://hashgraphontology.xyz/core/Transaction"
+        "@id": "https://hashgraphontology.xyz/core/ConsensusNodeEndpoint"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "targets topic"
+        "@value": "has endpoint address"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusTopic"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Links a transaction to the consensus topic it configures or submits to."
+        "@value": "Network address for a consensus node endpoint."
       }
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/isMirroredBy",
+    "@id": "https://hashgraphontology.xyz/core/hasEndpointPort",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#domain": [
       {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusRecordFile"
+        "@id": "https://hashgraphontology.xyz/core/ConsensusNodeEndpoint"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "is mirrored by"
+        "@value": "has endpoint port"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://hashgraphontology.xyz/core/MirrorDataset"
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Indicates which mirror dataset republishes a record file."
+        "@value": "Port number for a consensus node endpoint."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/consensus",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Ontology"
+    ],
+    "http://purl.org/dc/terms/created": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2024-09-20"
+      }
+    ],
+    "http://purl.org/dc/terms/creator": [
+      {
+        "@language": "en",
+        "@value": "Bhash Ontology Working Group"
+      }
+    ],
+    "http://purl.org/dc/terms/description": [
+      {
+        "@language": "en",
+        "@value": "Service-specific vocabulary for modelling Hedera Consensus Service topics, messages, and validator interfaces."
+      }
+    ],
+    "http://purl.org/dc/terms/modified": [
+      {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2024-09-20"
+      }
+    ],
+    "http://purl.org/dc/terms/title": [
+      {
+        "@language": "en",
+        "@value": "Hedera Consensus Service module"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#imports": [
+      {
+        "@id": "https://hashgraphontology.xyz/core"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#versionInfo": [
+      {
+        "@value": "0.1.0-dev"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#editorialNote": [
+      {
+        "@language": "en",
+        "@value": "Phase 3 sprint scaffold capturing core Consensus Service artefacts required for validator onboarding and topic governance competency questions."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/ConsensusService",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Consensus Service"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Service"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Operational service that orders transactions, emits consensus timestamps, and manages topics."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasSubmitKey",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusTopic"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has submit key"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/TopicSubmitKey"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/hasTopicKey"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Identifies the submit key required for message submission."
       }
     ]
   },
@@ -84,6 +197,44 @@
     ]
   },
   {
+    "@id": "https://hashgraphontology.xyz/core/hasSteward",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/GovernanceProcess"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has steward"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/GovernanceBody"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/hasParticipant"
+      }
+    ],
+    "http://www.w3.org/2002/07/owl#inverseOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/stewardsProcess"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Links a governance process to the council body that stewards the decision."
+      }
+    ]
+  },
+  {
     "@id": "https://hashgraphontology.xyz/core/ValidatorOnboardingCommittee",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -112,6 +263,90 @@
     ]
   },
   {
+    "@id": "https://hashgraphontology.xyz/core/includesMessage",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusRecordFile"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "includes message"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/TopicMessage"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Associates a record file with the topic messages it contains."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/deliversMessage",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusService"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "delivers message"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/TopicMessage"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Links the Consensus Service to messages that achieved consensus ordering."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/exposesEndpoint",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusNode"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "exposes endpoint"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusNodeEndpoint"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relates a consensus node to the endpoint clients use for gRPC/SDK submissions."
+      }
+    ]
+  },
+  {
     "@id": "https://hashgraphontology.xyz/core/hasConsensusTimestamp",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
@@ -129,10 +364,10 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "http://www.w3.org/2001/XMLSchema#dateTime"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
       {
         "@id": "http://www.w3.org/ns/prov#generatedAtTime"
       }
@@ -140,7 +375,13 @@
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Consensus-assigned timestamp recording when the topic message achieved ordering finality."
+        "@value": "Consensus-assigned timestamp recording when the topic message achieved ordering finality, in the native Hedera form \"seconds.nanoseconds\": Unix epoch seconds followed by exactly nine zero-padded nanosecond digits, as returned by the mirror node REST API (e.g. \"1586567700.453054000\")."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#editorialNote": [
+      {
+        "@language": "en",
+        "@value": "Held as xsd:string rather than xsd:dateTime so the native value round-trips exactly and can be used directly as a mirror-node query key. Consequently the value is not temporally comparable in SPARQL; lexicographic order matches chronological order for as long as the seconds field keeps a fixed width. This property is therefore not a subproperty of prov:generatedAtTime, whose range is xsd:dateTime — the PROV term is referenced via rdfs:seeAlso instead."
       }
     ],
     "https://hashgraphontology.xyz/core/sourceDocument": [
@@ -174,6 +415,466 @@
       {
         "@language": "en",
         "@value": "Indicates that the service produces consensus record files for downstream consumption."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/CouncilCommittee",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Council committee"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/GovernanceBody"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Sub-structure of the Hedera Governing Council that manages delegated mandates such as finance or membership reviews."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://hedera.com/council"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/targetsTopic",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Transaction"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "targets topic"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusTopic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Links a transaction to the consensus topic it configures or submits to."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasSequenceNumber",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/TopicMessage"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has sequence number"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Consensus-assigned sequence number for a topic message."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/supportedBy",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Process"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "supported by"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/GovernanceDecision"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Associates a process with the governance decision or mandate that authorises it."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/ConsensusNodeEndpoint",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Consensus node endpoint"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Artefact"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Network endpoint (IP, port, TLS configuration) exposed by a consensus node for client submissions."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/staking/nodes"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/TopicSubmitKey",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Topic submit key"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/AccountKey"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Key that governs which actors may post messages to a consensus topic."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/permissions"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/ConsensusTopic",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Consensus topic"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Artefact"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ordered message channel configured with administrator, submit, and auto-renew keys."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/instanceIRIPattern": [
+      {
+        "@language": "en",
+        "@value": "https://hashgraphontology.xyz/resource/{network}/topic/{shard}.{realm}.{num}"
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/topics"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/TopicMessage",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Topic message"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Event"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Individual message submitted to a consensus topic and assigned a consensus timestamp."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/instanceIRIPattern": [
+      {
+        "@language": "en",
+        "@value": "https://hashgraphontology.xyz/resource/{network}/topic/{shard}.{realm}.{num}/message/{sequenceNumber}"
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasMessageContent",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/TopicMessage"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has message content"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Payload content of a topic message."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasTopic",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusService"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has topic"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusTopic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Associates the Consensus Service with the topics it manages."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/assignsRole",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/RoleAssignment"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "assigns role"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Role"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Indicates the role granted by a role assignment process."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasRunningHash",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusRecordFile"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has running hash"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#hexBinary"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Running hash stored within a consensus record file."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/RoleAssignment",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Role assignment"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Process"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Process that confers a specific governance or operational role to an actor."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/governing-the-network#council-committees"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/ValidatorOnboardingSteward",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Validator onboarding steward"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Role"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Role fulfilled by council members who oversee validator onboarding approvals and requirements."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://hips.hedera.com/hip/hip-840"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasMessageSize",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/TopicMessage"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has message size"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Size in bytes of the submitted topic message."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/isMirroredBy",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusRecordFile"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "is mirrored by"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/MirrorDataset"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Indicates which mirror dataset republishes a record file."
       }
     ]
   },
@@ -239,326 +940,6 @@
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/hasMessageSize",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/TopicMessage"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has message size"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Size in bytes of the submitted topic message."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasEndpointPort",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusNodeEndpoint"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has endpoint port"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Port number for a consensus node endpoint."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasMessageContent",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/TopicMessage"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has message content"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Payload content of a topic message."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/deliversMessage",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusService"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "delivers message"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/TopicMessage"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Links the Consensus Service to messages that achieved consensus ordering."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasTopic",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusService"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has topic"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusTopic"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Associates the Consensus Service with the topics it manages."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/CouncilCommittee",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "Council committee"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/GovernanceBody"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Sub-structure of the Hedera Governing Council that manages delegated mandates such as finance or membership reviews."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://hedera.com/council"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasEndpointAddress",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusNodeEndpoint"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has endpoint address"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Network address for a consensus node endpoint."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/TopicMessage",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "Topic message"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Event"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Individual message submitted to a consensus topic and assigned a consensus timestamp."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/instanceIRIPattern": [
-      {
-        "@language": "en",
-        "@value": "https://hashgraphontology.xyz/resource/{network}/topic/{shard}.{realm}.{num}/message/{sequenceNumber}"
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/ConsensusService",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "Consensus Service"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Service"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Operational service that orders transactions, emits consensus timestamps, and manages topics."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/ConsensusTopic",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "Consensus topic"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Artefact"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Ordered message channel configured with administrator, submit, and auto-renew keys."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/instanceIRIPattern": [
-      {
-        "@language": "en",
-        "@value": "https://hashgraphontology.xyz/resource/{network}/topic/{shard}.{realm}.{num}"
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/topics"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/exposesEndpoint",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusNode"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "exposes endpoint"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusNodeEndpoint"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Relates a consensus node to the endpoint clients use for gRPC/SDK submissions."
-      }
-    ]
-  },
-  {
     "@id": "https://hashgraphontology.xyz/core/TopicAdminKey",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -583,282 +964,6 @@
     "https://hashgraphontology.xyz/core/sourceDocument": [
       {
         "@id": "https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/permissions"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/TopicSubmitKey",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "Topic submit key"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/AccountKey"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Key that governs which actors may post messages to a consensus topic."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/permissions"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/ConsensusNodeEndpoint",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "Consensus node endpoint"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Artefact"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Network endpoint (IP, port, TLS configuration) exposed by a consensus node for client submissions."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/staking/nodes"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/isSubBodyOf",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/GovernanceBody"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "is sub-body of"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/GovernanceBody"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Captures committee hierarchies within the Hedera Governing Council."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/ValidatorOnboardingSteward",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "Validator onboarding steward"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Role"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Role fulfilled by council members who oversee validator onboarding approvals and requirements."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://hips.hedera.com/hip/hip-840"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/supportedBy",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Process"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "supported by"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/GovernanceDecision"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Associates a process with the governance decision or mandate that authorises it."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/consensus",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Ontology"
-    ],
-    "http://purl.org/dc/terms/created": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2024-09-20"
-      }
-    ],
-    "http://purl.org/dc/terms/creator": [
-      {
-        "@language": "en",
-        "@value": "Bhash Ontology Working Group"
-      }
-    ],
-    "http://purl.org/dc/terms/description": [
-      {
-        "@language": "en",
-        "@value": "Service-specific vocabulary for modelling Hedera Consensus Service topics, messages, and validator interfaces."
-      }
-    ],
-    "http://purl.org/dc/terms/modified": [
-      {
-        "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2024-09-20"
-      }
-    ],
-    "http://purl.org/dc/terms/title": [
-      {
-        "@language": "en",
-        "@value": "Hedera Consensus Service module"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#imports": [
-      {
-        "@id": "https://hashgraphontology.xyz/core"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#versionInfo": [
-      {
-        "@value": "0.1.0-dev"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#editorialNote": [
-      {
-        "@language": "en",
-        "@value": "Phase 3 sprint scaffold capturing core Consensus Service artefacts required for validator onboarding and topic governance competency questions."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasTopicKey",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusTopic"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has topic key"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/AccountKey"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Connects a consensus topic to its configured keys."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/includesMessage",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusRecordFile"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "includes message"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/TopicMessage"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Associates a record file with the topic messages it contains."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasRunningHash",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusRecordFile"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has running hash"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#hexBinary"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Running hash stored within a consensus record file."
       }
     ]
   },
@@ -901,19 +1006,19 @@
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/hasSteward",
+    "@id": "https://hashgraphontology.xyz/core/isSubBodyOf",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#domain": [
       {
-        "@id": "https://hashgraphontology.xyz/core/GovernanceProcess"
+        "@id": "https://hashgraphontology.xyz/core/GovernanceBody"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "has steward"
+        "@value": "is sub-body of"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
@@ -921,137 +1026,10 @@
         "@id": "https://hashgraphontology.xyz/core/GovernanceBody"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/hasParticipant"
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#inverseOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/stewardsProcess"
-      }
-    ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Links a governance process to the council body that stewards the decision."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasSequenceNumber",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/TopicMessage"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has sequence number"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Consensus-assigned sequence number for a topic message."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/assignsRole",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/RoleAssignment"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "assigns role"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Role"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Indicates the role granted by a role assignment process."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasSubmitKey",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ConsensusTopic"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has submit key"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/TopicSubmitKey"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/hasTopicKey"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Identifies the submit key required for message submission."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/RoleAssignment",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "Role assignment"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Process"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Process that confers a specific governance or operational role to an actor."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/governing-the-network#council-committees"
+        "@value": "Captures committee hierarchies within the Hedera Governing Council."
       }
     ]
   },
@@ -1080,6 +1058,34 @@
       {
         "@language": "en",
         "@value": "String identifier representing the canonical topic ID (shard.realm.num)."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasTopicKey",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ConsensusTopic"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has topic key"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/AccountKey"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Connects a consensus topic to its configured keys."
       }
     ]
   }

--- a/ontology/deployment/consensus.owl
+++ b/ontology/deployment/consensus.owl
@@ -7,76 +7,15 @@
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 >
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/isMirroredBy">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">is mirrored by</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusRecordFile"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/MirrorDataset"/>
-    <skos:definition xml:lang="en">Indicates which mirror dataset republishes a record file.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasMessageContent">
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasConsensusTimestamp">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has message content</rdfs:label>
+    <rdfs:label xml:lang="en">has consensus timestamp</rdfs:label>
     <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <skos:definition xml:lang="en">Payload content of a topic message.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasAdminKey">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">has admin key</rdfs:label>
-    <rdfs:subPropertyOf rdf:resource="https://hashgraphontology.xyz/core/hasTopicKey"/>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/TopicAdminKey"/>
-    <skos:definition xml:lang="en">Identifies the admin key responsible for topic lifecycle changes.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ValidatorOnboardingCommittee">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Validator onboarding committee</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/CouncilCommittee"/>
-    <skos:definition xml:lang="en">Council committee that stewards validator onboarding cohorts and associated policy decisions.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://raw.githubusercontent.com/hashgraph/hedera-docs/main/core-concepts/staking/staking.md#phase-iii-staking-rewards-program-launch"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasTopicKey">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">has topic key</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/AccountKey"/>
-    <skos:definition xml:lang="en">Connects a consensus topic to its configured keys.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ConsensusNodeEndpoint">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Consensus node endpoint</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
-    <skos:definition xml:lang="en">Network endpoint (IP, port, TLS configuration) exposed by a consensus node for client submissions.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/staking/nodes"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/deliversMessage">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">delivers message</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusService"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
-    <skos:definition xml:lang="en">Links the Consensus Service to messages that achieved consensus ordering.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/CouncilCommittee">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Council committee</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/GovernanceBody"/>
-    <skos:definition xml:lang="en">Sub-structure of the Hedera Governing Council that manages delegated mandates such as finance or membership reviews.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://hedera.com/council"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ValidatorOnboardingSteward">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Validator onboarding steward</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Role"/>
-    <skos:definition xml:lang="en">Role fulfilled by council members who oversee validator onboarding approvals and requirements.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://hips.hedera.com/hip/hip-840"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/includesMessage">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">includes message</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusRecordFile"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
-    <skos:definition xml:lang="en">Associates a record file with the topic messages it contains.</skos:definition>
+    <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/prov#generatedAtTime"/>
+    <skos:definition xml:lang="en">Consensus-assigned timestamp recording when the topic message achieved ordering finality, in the native Hedera form "seconds.nanoseconds": Unix epoch seconds followed by exactly nine zero-padded nanosecond digits, as returned by the mirror node REST API (e.g. "1586567700.453054000").</skos:definition>
+    <skos:editorialNote xml:lang="en">Held as xsd:string rather than xsd:dateTime so the native value round-trips exactly and can be used directly as a mirror-node query key. Consequently the value is not temporally comparable in SPARQL; lexicographic order matches chronological order for as long as the seconds field keeps a fixed width. This property is therefore not a subproperty of prov:generatedAtTime, whose range is xsd:dateTime — the PROV term is referenced via rdfs:seeAlso instead.</skos:editorialNote>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/core/TopicAdminKey">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
@@ -84,139 +23,6 @@
     <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/AccountKey"/>
     <skos:definition xml:lang="en">Key that authorises topic-level administration such as update, delete, and re-key operations.</skos:definition>
     <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/permissions"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasTopic">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">has topic</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusService"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
-    <skos:definition xml:lang="en">Associates the Consensus Service with the topics it manages.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/assignsRole">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">assigns role</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/RoleAssignment"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/Role"/>
-    <skos:definition xml:lang="en">Indicates the role granted by a role assignment process.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasRunningHash">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has running hash</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusRecordFile"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
-    <skos:definition xml:lang="en">Running hash stored within a consensus record file.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/TopicSubmitKey">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Topic submit key</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/AccountKey"/>
-    <skos:definition xml:lang="en">Key that governs which actors may post messages to a consensus topic.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/permissions"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/TopicMessage">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Topic message</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Event"/>
-    <skos:definition xml:lang="en">Individual message submitted to a consensus topic and assigned a consensus timestamp.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows"/>
-    <hedera:instanceIRIPattern xml:lang="en">https://hashgraphontology.xyz/resource/{network}/topic/{shard}.{realm}.{num}/message/{sequenceNumber}</hedera:instanceIRIPattern>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/isSubBodyOf">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">is sub-body of</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/GovernanceBody"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/GovernanceBody"/>
-    <skos:definition xml:lang="en">Captures committee hierarchies within the Hedera Governing Council.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasSubmitKey">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">has submit key</rdfs:label>
-    <rdfs:subPropertyOf rdf:resource="https://hashgraphontology.xyz/core/hasTopicKey"/>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/TopicSubmitKey"/>
-    <skos:definition xml:lang="en">Identifies the submit key required for message submission.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasConsensusTimestamp">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has consensus timestamp</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#generatedAtTime"/>
-    <skos:definition xml:lang="en">Consensus-assigned timestamp recording when the topic message achieved ordering finality.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ConsensusRecordFile">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Consensus record file</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
-    <skos:definition xml:lang="en">Exported record file containing ordered transactions, consensus timestamps, and running hashes.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/mirror-node/architecture/record-and-balance-files"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/emitsRecordFile">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">emits record file</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusService"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ConsensusRecordFile"/>
-    <skos:definition xml:lang="en">Indicates that the service produces consensus record files for downstream consumption.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ConsensusTopic">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Consensus topic</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
-    <skos:definition xml:lang="en">Ordered message channel configured with administrator, submit, and auto-renew keys.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/topics"/>
-    <hedera:instanceIRIPattern xml:lang="en">https://hashgraphontology.xyz/resource/{network}/topic/{shard}.{realm}.{num}</hedera:instanceIRIPattern>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/supportedBy">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">supported by</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/Process"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/GovernanceDecision"/>
-    <skos:definition xml:lang="en">Associates a process with the governance decision or mandate that authorises it.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasSteward">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">has steward</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/GovernanceProcess"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/GovernanceBody"/>
-    <rdfs:subPropertyOf rdf:resource="https://hashgraphontology.xyz/core/hasParticipant"/>
-    <owl:inverseOf rdf:resource="https://hashgraphontology.xyz/core/stewardsProcess"/>
-    <skos:definition xml:lang="en">Links a governance process to the council body that stewards the decision.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasMessageSize">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has message size</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-    <skos:definition xml:lang="en">Size in bytes of the submitted topic message.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasTopicId">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has topic ID</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <skos:definition xml:lang="en">String identifier representing the canonical topic ID (shard.realm.num).</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/RoleAssignment">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Role assignment</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Process"/>
-    <skos:definition xml:lang="en">Process that confers a specific governance or operational role to an actor.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/governing-the-network#council-committees"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ConsensusService">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Consensus Service</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Service"/>
-    <skos:definition xml:lang="en">Operational service that orders transactions, emits consensus timestamps, and manages topics.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasSequenceNumber">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has sequence number</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-    <skos:definition xml:lang="en">Consensus-assigned sequence number for a topic message.</skos:definition>
   </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/consensus">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
@@ -229,12 +35,40 @@
     <owl:versionInfo>0.1.0-dev</owl:versionInfo>
     <skos:editorialNote xml:lang="en">Phase 3 sprint scaffold capturing core Consensus Service artefacts required for validator onboarding and topic governance competency questions.</skos:editorialNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/inTopic">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">in topic</rdfs:label>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasMessageSize">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has message size</rdfs:label>
     <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
-    <skos:definition xml:lang="en">Links a topic message to the consensus topic it belongs to.</skos:definition>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+    <skos:definition xml:lang="en">Size in bytes of the submitted topic message.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ValidatorOnboardingCommittee">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Validator onboarding committee</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/CouncilCommittee"/>
+    <skos:definition xml:lang="en">Council committee that stewards validator onboarding cohorts and associated policy decisions.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://raw.githubusercontent.com/hashgraph/hedera-docs/main/core-concepts/staking/staking.md#phase-iii-staking-rewards-program-launch"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ConsensusNodeEndpoint">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Consensus node endpoint</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
+    <skos:definition xml:lang="en">Network endpoint (IP, port, TLS configuration) exposed by a consensus node for client submissions.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/staking/nodes"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/includesMessage">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">includes message</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusRecordFile"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
+    <skos:definition xml:lang="en">Associates a record file with the topic messages it contains.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasSequenceNumber">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has sequence number</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+    <skos:definition xml:lang="en">Consensus-assigned sequence number for a topic message.</skos:definition>
   </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasEndpointAddress">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
@@ -242,6 +76,78 @@
     <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusNodeEndpoint"/>
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
     <skos:definition xml:lang="en">Network address for a consensus node endpoint.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/deliversMessage">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">delivers message</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusService"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
+    <skos:definition xml:lang="en">Links the Consensus Service to messages that achieved consensus ordering.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ConsensusRecordFile">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Consensus record file</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
+    <skos:definition xml:lang="en">Exported record file containing ordered transactions, consensus timestamps, and running hashes.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/mirror-node/architecture/record-and-balance-files"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasRunningHash">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has running hash</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusRecordFile"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#hexBinary"/>
+    <skos:definition xml:lang="en">Running hash stored within a consensus record file.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/assignsRole">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">assigns role</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/RoleAssignment"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/Role"/>
+    <skos:definition xml:lang="en">Indicates the role granted by a role assignment process.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasSubmitKey">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">has submit key</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="https://hashgraphontology.xyz/core/hasTopicKey"/>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/TopicSubmitKey"/>
+    <skos:definition xml:lang="en">Identifies the submit key required for message submission.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/CouncilCommittee">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Council committee</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/GovernanceBody"/>
+    <skos:definition xml:lang="en">Sub-structure of the Hedera Governing Council that manages delegated mandates such as finance or membership reviews.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://hedera.com/council"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasTopicKey">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">has topic key</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/AccountKey"/>
+    <skos:definition xml:lang="en">Connects a consensus topic to its configured keys.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/isMirroredBy">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">is mirrored by</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusRecordFile"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/MirrorDataset"/>
+    <skos:definition xml:lang="en">Indicates which mirror dataset republishes a record file.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/TopicMessage">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Topic message</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Event"/>
+    <skos:definition xml:lang="en">Individual message submitted to a consensus topic and assigned a consensus timestamp.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows"/>
+    <hedera:instanceIRIPattern xml:lang="en">https://hashgraphontology.xyz/resource/{network}/topic/{shard}.{realm}.{num}/message/{sequenceNumber}</hedera:instanceIRIPattern>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/RoleAssignment">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Role assignment</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Process"/>
+    <skos:definition xml:lang="en">Process that confers a specific governance or operational role to an actor.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/governing-the-network#council-committees"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/core/stewardsProcess">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -252,12 +158,51 @@
     <owl:inverseOf rdf:resource="https://hashgraphontology.xyz/core/hasSteward"/>
     <skos:definition xml:lang="en">Identifies the governance process that a council body is accountable for overseeing.</skos:definition>
   </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/targetsTopic">
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/isSubBodyOf">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">targets topic</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/Transaction"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
-    <skos:definition xml:lang="en">Links a transaction to the consensus topic it configures or submits to.</skos:definition>
+    <rdfs:label xml:lang="en">is sub-body of</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/GovernanceBody"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/GovernanceBody"/>
+    <skos:definition xml:lang="en">Captures committee hierarchies within the Hedera Governing Council.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasTopicId">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has topic ID</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <skos:definition xml:lang="en">String identifier representing the canonical topic ID (shard.realm.num).</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ValidatorOnboardingSteward">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Validator onboarding steward</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Role"/>
+    <skos:definition xml:lang="en">Role fulfilled by council members who oversee validator onboarding approvals and requirements.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://hips.hedera.com/hip/hip-840"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasAdminKey">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">has admin key</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="https://hashgraphontology.xyz/core/hasTopicKey"/>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/TopicAdminKey"/>
+    <skos:definition xml:lang="en">Identifies the admin key responsible for topic lifecycle changes.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasSteward">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">has steward</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/GovernanceProcess"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/GovernanceBody"/>
+    <rdfs:subPropertyOf rdf:resource="https://hashgraphontology.xyz/core/hasParticipant"/>
+    <owl:inverseOf rdf:resource="https://hashgraphontology.xyz/core/stewardsProcess"/>
+    <skos:definition xml:lang="en">Links a governance process to the council body that stewards the decision.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ConsensusTopic">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Consensus topic</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
+    <skos:definition xml:lang="en">Ordered message channel configured with administrator, submit, and auto-renew keys.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/topics"/>
+    <hedera:instanceIRIPattern xml:lang="en">https://hashgraphontology.xyz/resource/{network}/topic/{shard}.{realm}.{num}</hedera:instanceIRIPattern>
   </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasEndpointPort">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
@@ -266,11 +211,67 @@
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
     <skos:definition xml:lang="en">Port number for a consensus node endpoint.</skos:definition>
   </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasMessageContent">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has message content</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <skos:definition xml:lang="en">Payload content of a topic message.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ConsensusService">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Consensus Service</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Service"/>
+    <skos:definition xml:lang="en">Operational service that orders transactions, emits consensus timestamps, and manages topics.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasTopic">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">has topic</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusService"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
+    <skos:definition xml:lang="en">Associates the Consensus Service with the topics it manages.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/emitsRecordFile">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">emits record file</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusService"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ConsensusRecordFile"/>
+    <skos:definition xml:lang="en">Indicates that the service produces consensus record files for downstream consumption.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/inTopic">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">in topic</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/TopicMessage"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
+    <skos:definition xml:lang="en">Links a topic message to the consensus topic it belongs to.</skos:definition>
+  </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/core/exposesEndpoint">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
     <rdfs:label xml:lang="en">exposes endpoint</rdfs:label>
     <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ConsensusNode"/>
     <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ConsensusNodeEndpoint"/>
     <skos:definition xml:lang="en">Relates a consensus node to the endpoint clients use for gRPC/SDK submissions.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/supportedBy">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">supported by</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/Process"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/GovernanceDecision"/>
+    <skos:definition xml:lang="en">Associates a process with the governance decision or mandate that authorises it.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/TopicSubmitKey">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Topic submit key</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/AccountKey"/>
+    <skos:definition xml:lang="en">Key that governs which actors may post messages to a consensus topic.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/permissions"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/targetsTopic">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">targets topic</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/Transaction"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ConsensusTopic"/>
+    <skos:definition xml:lang="en">Links a transaction to the consensus topic it configures or submits to.</skos:definition>
   </rdf:Description>
 </rdf:RDF>

--- a/ontology/deployment/consensus.ttl
+++ b/ontology/deployment/consensus.ttl
@@ -62,9 +62,10 @@ hedera:hasAdminKey a owl:ObjectProperty ;
 hedera:hasConsensusTimestamp a owl:DatatypeProperty ;
     rdfs:label "has consensus timestamp"@en ;
     rdfs:domain hedera:TopicMessage ;
-    rdfs:range xsd:dateTime ;
-    rdfs:subPropertyOf prov:generatedAtTime ;
-    skos:definition "Consensus-assigned timestamp recording when the topic message achieved ordering finality."@en ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso prov:generatedAtTime ;
+    skos:definition "Consensus-assigned timestamp recording when the topic message achieved ordering finality, in the native Hedera form \"seconds.nanoseconds\": Unix epoch seconds followed by exactly nine zero-padded nanosecond digits, as returned by the mirror node REST API (e.g. \"1586567700.453054000\")."@en ;
+    skos:editorialNote "Held as xsd:string rather than xsd:dateTime so the native value round-trips exactly and can be used directly as a mirror-node query key. Consequently the value is not temporally comparable in SPARQL; lexicographic order matches chronological order for as long as the seconds field keeps a fixed width. This property is therefore not a subproperty of prov:generatedAtTime, whose range is xsd:dateTime — the PROV term is referenced via rdfs:seeAlso instead."@en ;
     hedera:sourceDocument <https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows> .
 
 hedera:hasEndpointAddress a owl:DatatypeProperty ;

--- a/ontology/deployment/file-schedule.html
+++ b/ontology/deployment/file-schedule.html
@@ -52,11 +52,11 @@
             
                 <tr><td>hedera</td><td>https://hashgraphontology.xyz/core/</td></tr>
             
-                <tr><td>ns1</td><td>https://hashgraphontology.xyz/</td></tr>
+                <tr><td>ns1</td><td>https://docs.hedera.com/hedera/core-concepts/file-service/</td></tr>
             
-                <tr><td>ns2</td><td>https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/</td></tr>
+                <tr><td>ns2</td><td>https://hashgraphontology.xyz/</td></tr>
             
-                <tr><td>ns3</td><td>https://docs.hedera.com/hedera/core-concepts/file-service/</td></tr>
+                <tr><td>ns3</td><td>https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/</td></tr>
             
                 <tr><td>ns4</td><td>https://docs.hedera.com/hedera/core-concepts/</td></tr>
             
@@ -357,7 +357,7 @@
                     <td>hedera:hasScheduleExpiration</td>
                     <td>DatatypeProperty</td>
                     <td><span class="pill">hedera:ScheduledTransaction</span></td>
-                    <td><span class="pill">xsd:dateTime</span></td>
+                    <td><span class="pill">xsd:string</span></td>
                     <td class="small">
                         
                         

--- a/ontology/deployment/file-schedule.jsonld
+++ b/ontology/deployment/file-schedule.jsonld
@@ -1,62 +1,67 @@
 [
   {
-    "@id": "https://hashgraphontology.xyz/core/PendingSchedule",
+    "@id": "https://hashgraphontology.xyz/core/performedBy",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/FileUpdate"
+      }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "Pending schedule"
+        "@value": "performed by"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Account"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
+      {
+        "@id": "http://www.w3.org/ns/prov#wasAssociatedWith"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Identifies the account that submitted the file update."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasScheduleMemo",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
       {
         "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
       }
     ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Scheduled transaction that has not yet gathered sufficient signatures."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/scheduled-transactions"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "Scheduled transaction"
+        "@value": "has schedule memo"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://hashgraphontology.xyz/core/Artefact"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Deferred transaction waiting for a quorum of signatures before execution."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work"
+        "@value": "Memo describing the scheduled transaction purpose."
       }
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/hasExecution",
+    "@id": "https://hashgraphontology.xyz/core/hasCollectedSignature",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
@@ -68,102 +73,18 @@
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "has execution"
+        "@value": "has collected signature"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://hashgraphontology.xyz/core/ScheduleExecution"
+        "@id": "https://hashgraphontology.xyz/core/ScheduleSignature"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Associates a scheduled transaction with its execution once signatures complete."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasFileId",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/File"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has file id"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Ledger identifier (e.g., 0.0.x) for a file."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasScheduleStatus",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has schedule status"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Enumerated status such as pending-signatures, executed, or expired."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasCollectedSignatureCount",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has collected signature count"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Number of signatures collected so far for the schedule."
+        "@value": "Connects a scheduled transaction to signatures already obtained."
       }
     ]
   },
@@ -220,263 +141,6 @@
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/hasFileMemo",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/File"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has file memo"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Memo describing file purpose or metadata."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasScheduleMemo",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has schedule memo"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Memo describing the scheduled transaction purpose."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/storesArtefact",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/File"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "stores artefact"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Artefact"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Indicates that a file stores an artefact such as bytecode or fee schedules."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasScheduleId",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has schedule id"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Ledger identifier for a scheduled transaction."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasSchedulePayer",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has schedule payer"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#string"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Account identifier paying for schedule execution."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasCollectedSignature",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has collected signature"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ScheduleSignature"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Connects a scheduled transaction to signatures already obtained."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/expiresWith",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "expires with"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Event"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Identifies the event that marks the expiration of a scheduled transaction."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/performedBy",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/FileUpdate"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "performed by"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Account"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [
-      {
-        "@id": "http://www.w3.org/ns/prov#wasAssociatedWith"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Identifies the account that submitted the file update."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/requiresSignature",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "requires signature"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Account"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Identifies accounts whose signatures are required for a scheduled transaction."
-      }
-    ]
-  },
-  {
     "@id": "https://hashgraphontology.xyz/core/ScheduleExecution",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -505,58 +169,30 @@
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/File",
+    "@id": "https://hashgraphontology.xyz/core/hasCollectedSignatureCount",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "File"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/Artefact"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "On-ledger file storing bytecode, configuration, or metadata referenced by other services."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/file-service/file-storage"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasFileKey",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#domain": [
       {
-        "@id": "https://hashgraphontology.xyz/core/File"
+        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "has file key"
+        "@value": "has collected signature count"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://hashgraphontology.xyz/core/FileKey"
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Associates a file with the keys authorised to modify it."
+        "@value": "Number of signatures collected so far for the schedule."
       }
     ]
   },
@@ -589,9 +225,37 @@
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/hasFileContent",
+    "@id": "https://hashgraphontology.xyz/core/FileContent",
     "@type": [
-      "http://www.w3.org/2002/07/owl#ObjectProperty"
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "File content"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Artefact"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Payload stored within a File Service file such as contract bytecode or fee schedules."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/file-service/file-storage"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasFileMemo",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
     "http://www.w3.org/2000/01/rdf-schema#domain": [
       {
@@ -601,46 +265,18 @@
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "has file content"
+        "@value": "has file memo"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://hashgraphontology.xyz/core/FileContent"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Links a file to the payload stored within it."
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/hasScheduleExpiration",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#DatatypeProperty"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#domain": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "has schedule expiration"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#range": [
-      {
-        "@id": "http://www.w3.org/2001/XMLSchema#dateTime"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Timestamp at which the scheduled transaction expires."
+        "@value": "Memo describing file purpose or metadata."
       }
     ]
   },
@@ -669,6 +305,90 @@
     "https://hashgraphontology.xyz/core/sourceDocument": [
       {
         "@id": "https://docs.hedera.com/hedera/core-concepts/file-service/update-files"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/storesArtefact",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/File"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "stores artefact"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Artefact"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Indicates that a file stores an artefact such as bytecode or fee schedules."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/FileKey",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "File key"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/AccountKey"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Key that authorises file creation, update, and deletion actions."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/file-service/file-keys"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasSchedulePayer",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has schedule payer"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Account identifier paying for schedule execution."
       }
     ]
   },
@@ -729,30 +449,282 @@
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/ScheduleService",
+    "@id": "https://hashgraphontology.xyz/core/schedulesTransaction",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "schedules transaction"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Process"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Links a scheduled transaction artefact to the process that will execute once signatures are collected."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasFileKey",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/File"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has file key"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/FileKey"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Associates a file with the keys authorised to modify it."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasScheduleStatus",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has schedule status"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Enumerated status such as pending-signatures, executed, or expired."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/PendingSchedule",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "Schedule Service"
+        "@value": "Pending schedule"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
-        "@id": "https://hashgraphontology.xyz/core/Service"
+        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Service that queues transactions for deferred execution once signature requirements are met."
+        "@value": "Scheduled transaction that has not yet gathered sufficient signatures."
       }
     ],
     "https://hashgraphontology.xyz/core/sourceDocument": [
       {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/introduction"
+        "@id": "https://docs.hedera.com/hedera/core-concepts/scheduled-transactions"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Scheduled transaction"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Artefact"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Deferred transaction waiting for a quorum of signatures before execution."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasScheduleId",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has schedule id"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ledger identifier for a scheduled transaction."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasRequiredSignatureCount",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has required signature count"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Number of signatures needed before execution."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/hasFileId",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/File"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "has file id"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ledger identifier (e.g., 0.0.x) for a file."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/expiresWith",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "expires with"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Event"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Identifies the event that marks the expiration of a scheduled transaction."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/File",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "File"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Artefact"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "On-ledger file storing bytecode, configuration, or metadata referenced by other services."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/file-service/file-storage"
       }
     ]
   },
@@ -785,35 +757,7 @@
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/FileKey",
-    "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
-      {
-        "@language": "en",
-        "@value": "File key"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://hashgraphontology.xyz/core/AccountKey"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Key that authorises file creation, update, and deletion actions."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/file-service/file-keys"
-      }
-    ]
-  },
-  {
-    "@id": "https://hashgraphontology.xyz/core/schedulesTransaction",
+    "@id": "https://hashgraphontology.xyz/core/hasExecution",
     "@type": [
       "http://www.w3.org/2002/07/owl#ObjectProperty"
     ],
@@ -825,51 +769,51 @@
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "schedules transaction"
+        "@value": "has execution"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://hashgraphontology.xyz/core/Process"
+        "@id": "https://hashgraphontology.xyz/core/ScheduleExecution"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Links a scheduled transaction artefact to the process that will execute once signatures are collected."
+        "@value": "Associates a scheduled transaction with its execution once signatures complete."
       }
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/FileContent",
+    "@id": "https://hashgraphontology.xyz/core/hasFileContent",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/File"
+      }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "File content"
+        "@value": "has file content"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://hashgraphontology.xyz/core/Artefact"
+        "@id": "https://hashgraphontology.xyz/core/FileContent"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Payload stored within a File Service file such as contract bytecode or fee schedules."
-      }
-    ],
-    "https://hashgraphontology.xyz/core/sourceDocument": [
-      {
-        "@id": "https://docs.hedera.com/hedera/core-concepts/file-service/file-storage"
+        "@value": "Links a file to the payload stored within it."
       }
     ]
   },
   {
-    "@id": "https://hashgraphontology.xyz/core/hasRequiredSignatureCount",
+    "@id": "https://hashgraphontology.xyz/core/hasScheduleExpiration",
     "@type": [
       "http://www.w3.org/2002/07/owl#DatatypeProperty"
     ],
@@ -881,18 +825,80 @@
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "has required signature count"
+        "@value": "has schedule expiration"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "http://www.w3.org/2001/XMLSchema#integer"
+        "@id": "http://www.w3.org/2001/XMLSchema#string"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Number of signatures needed before execution."
+        "@value": "Timestamp at which the scheduled transaction expires, in the native Hedera form \"seconds.nanoseconds\": Unix epoch seconds followed by exactly nine zero-padded nanosecond digits, as returned by the mirror node REST API (e.g. \"1633046400.000000000\")."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#editorialNote": [
+      {
+        "@language": "en",
+        "@value": "Held as xsd:string rather than xsd:dateTime for the same reason as hedera:hasConsensusTimestamp: the native value round-trips exactly and is usable directly as a mirror-node query key."
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/ScheduleService",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Schedule Service"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Service"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Service that queues transactions for deferred execution once signature requirements are met."
+      }
+    ],
+    "https://hashgraphontology.xyz/core/sourceDocument": [
+      {
+        "@id": "https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/introduction"
+      }
+    ]
+  },
+  {
+    "@id": "https://hashgraphontology.xyz/core/requiresSignature",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#ObjectProperty"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#domain": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/ScheduledTransaction"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "requires signature"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#range": [
+      {
+        "@id": "https://hashgraphontology.xyz/core/Account"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Identifies accounts whose signatures are required for a scheduled transaction."
       }
     ]
   }

--- a/ontology/deployment/file-schedule.owl
+++ b/ontology/deployment/file-schedule.owl
@@ -7,12 +7,132 @@
    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 >
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasRequiredSignatureCount">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has required signature count</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+    <skos:definition xml:lang="en">Number of signatures needed before execution.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/schedulesTransaction">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">schedules transaction</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/Process"/>
+    <skos:definition xml:lang="en">Links a scheduled transaction artefact to the process that will execute once signatures are collected.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasExecution">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">has execution</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ScheduleExecution"/>
+    <skos:definition xml:lang="en">Associates a scheduled transaction with its execution once signatures complete.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ScheduleExecution">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Schedule execution</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Process"/>
+    <skos:definition xml:lang="en">Process that executes a scheduled transaction once all required signatures are collected.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/FileKey">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">File key</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/AccountKey"/>
+    <skos:definition xml:lang="en">Key that authorises file creation, update, and deletion actions.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/file-service/file-keys"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ScheduleSignature">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Schedule signature</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
+    <skos:definition xml:lang="en">Signature provided by an account approving a scheduled transaction.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/PendingSchedule">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">Pending schedule</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <skos:definition xml:lang="en">Scheduled transaction that has not yet gathered sufficient signatures.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/scheduled-transactions"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/FileUpdate">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">File update</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Process"/>
+    <skos:definition xml:lang="en">Process that amends file contents or metadata under the control of file keys.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/file-service/update-files"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasFileId">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has file id</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/File"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <skos:definition xml:lang="en">Ledger identifier (e.g., 0.0.x) for a file.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasScheduleMemo">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has schedule memo</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <skos:definition xml:lang="en">Memo describing the scheduled transaction purpose.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/FileContent">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">File content</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
+    <skos:definition xml:lang="en">Payload stored within a File Service file such as contract bytecode or fee schedules.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/file-service/file-storage"/>
+  </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ScheduleService">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
     <rdfs:label xml:lang="en">Schedule Service</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Service"/>
     <skos:definition xml:lang="en">Service that queues transactions for deferred execution once signature requirements are met.</skos:definition>
     <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/introduction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/expiresWith">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">expires with</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/Event"/>
+    <skos:definition xml:lang="en">Identifies the event that marks the expiration of a scheduled transaction.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasFileSize">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has file size</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/File"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+    <skos:definition xml:lang="en">Size of file contents in bytes.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/requiresSignature">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">requires signature</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/Account"/>
+    <skos:definition xml:lang="en">Identifies accounts whose signatures are required for a scheduled transaction.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasSchedulePayer">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has schedule payer</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <skos:definition xml:lang="en">Account identifier paying for schedule execution.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/File">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label xml:lang="en">File</rdfs:label>
+    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
+    <skos:definition xml:lang="en">On-ledger file storing bytecode, configuration, or metadata referenced by other services.</skos:definition>
+    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/file-service/file-storage"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasScheduleExpiration">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has schedule expiration</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <skos:definition xml:lang="en">Timestamp at which the scheduled transaction expires, in the native Hedera form "seconds.nanoseconds": Unix epoch seconds followed by exactly nine zero-padded nanosecond digits, as returned by the mirror node REST API (e.g. "1633046400.000000000").</skos:definition>
+    <skos:editorialNote xml:lang="en">Held as xsd:string rather than xsd:dateTime for the same reason as hedera:hasConsensusTimestamp: the native value round-trips exactly and is usable directly as a mirror-node query key.</skos:editorialNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/file-schedule">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
@@ -25,40 +145,12 @@
     <owl:versionInfo>0.1.0-dev</owl:versionInfo>
     <skos:editorialNote xml:lang="en">Phase 3 sprint module integrating File Service bytecode storage and scheduled transaction governance for CQ-COMP-004.</skos:editorialNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasRequiredSignatureCount">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has required signature count</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-    <skos:definition xml:lang="en">Number of signatures needed before execution.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ScheduleSignature">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Schedule signature</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
-    <skos:definition xml:lang="en">Signature provided by an account approving a scheduled transaction.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ScheduleExecution">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Schedule execution</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Process"/>
-    <skos:definition xml:lang="en">Process that executes a scheduled transaction once all required signatures are collected.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/updatesFile">
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasFileContent">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">updates file</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/FileUpdate"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/File"/>
-    <skos:definition xml:lang="en">Connects a file update process to the file being modified.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasExecution">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">has execution</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ScheduleExecution"/>
-    <skos:definition xml:lang="en">Associates a scheduled transaction with its execution once signatures complete.</skos:definition>
+    <rdfs:label xml:lang="en">has file content</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/File"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/FileContent"/>
+    <skos:definition xml:lang="en">Links a file to the payload stored within it.</skos:definition>
   </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasCollectedSignature">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -67,125 +159,12 @@
     <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/ScheduleSignature"/>
     <skos:definition xml:lang="en">Connects a scheduled transaction to signatures already obtained.</skos:definition>
   </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/FileKey">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">File key</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/AccountKey"/>
-    <skos:definition xml:lang="en">Key that authorises file creation, update, and deletion actions.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/file-service/file-keys"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/performedBy">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">performed by</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/FileUpdate"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/Account"/>
-    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasAssociatedWith"/>
-    <skos:definition xml:lang="en">Identifies the account that submitted the file update.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasScheduleMemo">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has schedule memo</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <skos:definition xml:lang="en">Memo describing the scheduled transaction purpose.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasSchedulePayer">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has schedule payer</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <skos:definition xml:lang="en">Account identifier paying for schedule execution.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/PendingSchedule">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">Pending schedule</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <skos:definition xml:lang="en">Scheduled transaction that has not yet gathered sufficient signatures.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/scheduled-transactions"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasFileContent">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">has file content</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/File"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/FileContent"/>
-    <skos:definition xml:lang="en">Links a file to the payload stored within it.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasScheduleExpiration">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has schedule expiration</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
-    <skos:definition xml:lang="en">Timestamp at which the scheduled transaction expires.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasCollectedSignatureCount">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has collected signature count</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-    <skos:definition xml:lang="en">Number of signatures collected so far for the schedule.</skos:definition>
-  </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasFileMemo">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
     <rdfs:label xml:lang="en">has file memo</rdfs:label>
     <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/File"/>
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
     <skos:definition xml:lang="en">Memo describing file purpose or metadata.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/FileContent">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">File content</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
-    <skos:definition xml:lang="en">Payload stored within a File Service file such as contract bytecode or fee schedules.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/file-service/file-storage"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/expiresWith">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">expires with</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/Event"/>
-    <skos:definition xml:lang="en">Identifies the event that marks the expiration of a scheduled transaction.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/FileUpdate">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">File update</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Process"/>
-    <skos:definition xml:lang="en">Process that amends file contents or metadata under the control of file keys.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/file-service/update-files"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/File">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <rdfs:label xml:lang="en">File</rdfs:label>
-    <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Artefact"/>
-    <skos:definition xml:lang="en">On-ledger file storing bytecode, configuration, or metadata referenced by other services.</skos:definition>
-    <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/file-service/file-storage"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasFileKey">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">has file key</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/File"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/FileKey"/>
-    <skos:definition xml:lang="en">Associates a file with the keys authorised to modify it.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasFileId">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has file id</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/File"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <skos:definition xml:lang="en">Ledger identifier (e.g., 0.0.x) for a file.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasScheduleId">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has schedule id</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <skos:definition xml:lang="en">Ledger identifier for a scheduled transaction.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasScheduleStatus">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has schedule status</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-    <skos:definition xml:lang="en">Enumerated status such as pending-signatures, executed, or expired.</skos:definition>
   </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/core/ScheduledTransaction">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
@@ -194,26 +173,12 @@
     <skos:definition xml:lang="en">Deferred transaction waiting for a quorum of signatures before execution.</skos:definition>
     <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/scheduled-transactions/how-scheduled-transactions-work"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/requiresSignature">
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasFileKey">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">requires signature</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/Account"/>
-    <skos:definition xml:lang="en">Identifies accounts whose signatures are required for a scheduled transaction.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasFileSize">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
-    <rdfs:label xml:lang="en">has file size</rdfs:label>
+    <rdfs:label xml:lang="en">has file key</rdfs:label>
     <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/File"/>
-    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-    <skos:definition xml:lang="en">Size of file contents in bytes.</skos:definition>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/schedulesTransaction">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
-    <rdfs:label xml:lang="en">schedules transaction</rdfs:label>
-    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
-    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/Process"/>
-    <skos:definition xml:lang="en">Links a scheduled transaction artefact to the process that will execute once signatures are collected.</skos:definition>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/FileKey"/>
+    <skos:definition xml:lang="en">Associates a file with the keys authorised to modify it.</skos:definition>
   </rdf:Description>
   <rdf:Description rdf:about="https://hashgraphontology.xyz/core/storesArtefact">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
@@ -228,5 +193,41 @@
     <rdfs:subClassOf rdf:resource="https://hashgraphontology.xyz/core/Service"/>
     <skos:definition xml:lang="en">Network service that stores bytecode, fee schedules, and other artefacts under key-controlled files.</skos:definition>
     <hedera:sourceDocument rdf:resource="https://docs.hedera.com/hedera/core-concepts/file-service/introduction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasScheduleStatus">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has schedule status</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <skos:definition xml:lang="en">Enumerated status such as pending-signatures, executed, or expired.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasCollectedSignatureCount">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has collected signature count</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+    <skos:definition xml:lang="en">Number of signatures collected so far for the schedule.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/updatesFile">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">updates file</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/FileUpdate"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/File"/>
+    <skos:definition xml:lang="en">Connects a file update process to the file being modified.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/hasScheduleId">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:label xml:lang="en">has schedule id</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/ScheduledTransaction"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <skos:definition xml:lang="en">Ledger identifier for a scheduled transaction.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://hashgraphontology.xyz/core/performedBy">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:label xml:lang="en">performed by</rdfs:label>
+    <rdfs:domain rdf:resource="https://hashgraphontology.xyz/core/FileUpdate"/>
+    <rdfs:range rdf:resource="https://hashgraphontology.xyz/core/Account"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/prov#wasAssociatedWith"/>
+    <skos:definition xml:lang="en">Identifies the account that submitted the file update.</skos:definition>
   </rdf:Description>
 </rdf:RDF>

--- a/ontology/deployment/file-schedule.ttl
+++ b/ontology/deployment/file-schedule.ttl
@@ -87,8 +87,9 @@ hedera:hasRequiredSignatureCount a owl:DatatypeProperty ;
 hedera:hasScheduleExpiration a owl:DatatypeProperty ;
     rdfs:label "has schedule expiration"@en ;
     rdfs:domain hedera:ScheduledTransaction ;
-    rdfs:range xsd:dateTime ;
-    skos:definition "Timestamp at which the scheduled transaction expires."@en .
+    rdfs:range xsd:string ;
+    skos:definition "Timestamp at which the scheduled transaction expires, in the native Hedera form \"seconds.nanoseconds\": Unix epoch seconds followed by exactly nine zero-padded nanosecond digits, as returned by the mirror node REST API (e.g. \"1633046400.000000000\")."@en ;
+    skos:editorialNote "Held as xsd:string rather than xsd:dateTime for the same reason as hedera:hasConsensusTimestamp: the native value round-trips exactly and is usable directly as a mirror-node query key."@en .
 
 hedera:hasScheduleId a owl:DatatypeProperty ;
     rdfs:label "has schedule id"@en ;

--- a/ontology/examples/core-consensus.ttl
+++ b/ontology/examples/core-consensus.ttl
@@ -242,5 +242,5 @@ ex:TopicAlphaMessage987
     rdfs:label "Topic alpha message 987"@en ;
     hedera:inTopic ex:TopicAlpha ;
     hedera:hasSequenceNumber 987 ;
-    hedera:hasConsensusTimestamp "2026-03-09T10:11:12.123Z"^^xsd:dateTime ;
+    hedera:hasConsensusTimestamp "1773051072.123000000"^^xsd:string ;
     .

--- a/ontology/examples/file-schedule.ttl
+++ b/ontology/examples/file-schedule.ttl
@@ -43,7 +43,7 @@ exfs:EmergencyPauseSchedule
     hedera:hasSchedulePayer "0.0.5005" ;
     hedera:hasRequiredSignatureCount 3 ;
     hedera:hasCollectedSignatureCount 2 ;
-    hedera:hasScheduleExpiration "2025-10-01T00:00:00Z"^^xsd:dateTime ;
+    hedera:hasScheduleExpiration "1759276800.000000000"^^xsd:string ;
     hedera:requiresSignature exfs:SecurityCouncil , exfs:OperationsLead , exfs:ComplianceOfficer ;
     hedera:hasCollectedSignature exfs:SecurityCouncilSignature , exfs:OperationsLeadSignature ;
     hedera:schedulesTransaction exsc:SwapExecution ;

--- a/ontology/shapes/consensus.shacl.ttl
+++ b/ontology/shapes/consensus.shacl.ttl
@@ -18,9 +18,10 @@ hedera:TopicMessageShape
     sh:targetClass hedera:TopicMessage ;
     sh:property [
         sh:path hedera:hasConsensusTimestamp ;
-        sh:datatype xsd:dateTime ;
+        sh:datatype xsd:string ;
+        sh:pattern "^(0|[1-9][0-9]*)\\.[0-9]{9}$" ;
         sh:maxCount 1 ;
-        sh:message "A TopicMessage must have at most one consensus timestamp of type xsd:dateTime."@en ;
+        sh:message "A TopicMessage must have at most one consensus timestamp, an xsd:string in the native Hedera form seconds.nanoseconds with exactly nine nanosecond digits (e.g. 1586567700.453054000)."@en ;
     ] ;
     .
 

--- a/ontology/shapes/file-schedule.shacl.ttl
+++ b/ontology/shapes/file-schedule.shacl.ttl
@@ -25,8 +25,9 @@ hedera:PendingScheduleShape
     sh:property [
         sh:path hedera:hasScheduleExpiration ;
         sh:minCount 1 ;
-        sh:datatype xsd:dateTime ;
-        sh:message "Pending schedules must specify an expiration timestamp."@en ;
+        sh:datatype xsd:string ;
+        sh:pattern "^(0|[1-9][0-9]*)\\.[0-9]{9}$" ;
+        sh:message "Pending schedules must specify an expiration timestamp, an xsd:string in the native Hedera form seconds.nanoseconds with exactly nine nanosecond digits (e.g. 1633046400.000000000)."@en ;
     ] ;
     .
 

--- a/ontology/src/consensus.ttl
+++ b/ontology/src/consensus.ttl
@@ -316,8 +316,9 @@ hedera:hasConsensusTimestamp
     a owl:DatatypeProperty ;
     rdfs:label "has consensus timestamp"@en ;
     rdfs:domain hedera:TopicMessage ;
-    rdfs:range xsd:dateTime ;
-    rdfs:subPropertyOf prov:generatedAtTime ;
-    skos:definition "Consensus-assigned timestamp recording when the topic message achieved ordering finality."@en ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso prov:generatedAtTime ;
+    skos:definition "Consensus-assigned timestamp recording when the topic message achieved ordering finality, in the native Hedera form \"seconds.nanoseconds\": Unix epoch seconds followed by exactly nine zero-padded nanosecond digits, as returned by the mirror node REST API (e.g. \"1586567700.453054000\")."@en ;
+    skos:editorialNote "Held as xsd:string rather than xsd:dateTime so the native value round-trips exactly and can be used directly as a mirror-node query key. Consequently the value is not temporally comparable in SPARQL; lexicographic order matches chronological order for as long as the seconds field keeps a fixed width. This property is therefore not a subproperty of prov:generatedAtTime, whose range is xsd:dateTime — the PROV term is referenced via rdfs:seeAlso instead."@en ;
     hedera:sourceDocument <https://docs.hedera.com/hedera/core-concepts/hedera-consensus-service/message-flows> ;
     .

--- a/ontology/src/file-schedule.ttl
+++ b/ontology/src/file-schedule.ttl
@@ -241,8 +241,9 @@ hedera:hasScheduleExpiration
     a owl:DatatypeProperty ;
     rdfs:label "has schedule expiration"@en ;
     rdfs:domain hedera:ScheduledTransaction ;
-    rdfs:range xsd:dateTime ;
-    skos:definition "Timestamp at which the scheduled transaction expires."@en ;
+    rdfs:range xsd:string ;
+    skos:definition "Timestamp at which the scheduled transaction expires, in the native Hedera form \"seconds.nanoseconds\": Unix epoch seconds followed by exactly nine zero-padded nanosecond digits, as returned by the mirror node REST API (e.g. \"1633046400.000000000\")."@en ;
+    skos:editorialNote "Held as xsd:string rather than xsd:dateTime for the same reason as hedera:hasConsensusTimestamp: the native value round-trips exactly and is usable directly as a mirror-node query key."@en ;
     .
 
 hedera:hasRequiredSignatureCount

--- a/tests/fixtures/results/cq-comp-004.csv
+++ b/tests/fixtures/results/cq-comp-004.csv
@@ -1,2 +1,2 @@
 schedule,transaction,status,missingSignatures,expires
-https://hashgraphontology.xyz/examples/file/EmergencyPauseSchedule,https://hashgraphontology.xyz/examples/contracts/SwapExecution,pending-signatures,1,2025-10-01T00:00:00+00:00
+https://hashgraphontology.xyz/examples/file/EmergencyPauseSchedule,https://hashgraphontology.xyz/examples/contracts/SwapExecution,pending-signatures,1,1759276800.000000000

--- a/tests/fixtures/results/cq-con-001.csv
+++ b/tests/fixtures/results/cq-con-001.csv
@@ -1,2 +1,2 @@
 message,sequenceNumber,consensusTimestamp
-https://hashgraphontology.xyz/examples/core/TopicAlphaMessage987,987,2026-03-09T10:11:12.123000+00:00
+https://hashgraphontology.xyz/examples/core/TopicAlphaMessage987,987,1773051072.123000000


### PR DESCRIPTION
Fixes #65.

Re-ranges `hedera:hasConsensusTimestamp` from `xsd:dateTime` to `xsd:string` carrying the native Hedera `seconds.nanoseconds` value, per the issue. Three decisions beyond the one-line version, as discussed in the [issue comment](https://github.com/IndependentImpact/Bhash/issues/65#issuecomment-5202429408):

1. **The `prov:generatedAtTime` parent is dropped** (demoted to `rdfs:seeAlso`). PROV-O ranges `generatedAtTime` as `xsd:dateTime`; keeping the subproperty axiom while re-ranging to `xsd:string` would entail every value into two disjoint datatypes and make the ontology OWL-inconsistent. The trade-off — consensus timestamps are no longer temporally comparable in SPARQL — is recorded in a `skos:editorialNote`; lexicographic order matches chronological order while the seconds field keeps a fixed width (2001–2286).

2. **The SHACL pattern is the canonical mirror-node form** `^(0|[1-9][0-9]*)\.[0-9]{9}$` (nine zero-padded nanosecond digits), not the `^[0-9]{4,}\.[0-9]{4,}$` proposed on the issue. That regex is the legacy II `hed:HederaMessageId` string-ID check and is both too strict (rejects `1586567700.453`) and too loose (accepts `0000.0000` and nanos above `999999999`). The definitions now state the canonical form explicitly. Swapping back is a one-line change in each shape if preferred.

3. **`hedera:hasScheduleExpiration` is fixed in parallel** — same defect, no PROV parent, so the ontology doesn't end up representing Hedera instants two different ways.

Deployment artefacts are regenerated for the two affected modules only; `convert_ontologies.py` is not order-stable, so a full regeneration would rewrite every module with reordering noise.

**Verification** (repo has no CI; local runs against a fresh venv):
- `scripts/run_shacl.py` — output identical to `origin/main`: 0 violations, the same 12 pre-existing IRI-pattern warnings.
- `scripts/run_sparql.py` — output byte-identical to `origin/main`; the updated fixtures `cq-con-001` and `cq-comp-004` pass; the only mismatch (`cq-impact-001`) is pre-existing.
- `make` is currently broken on `main` (the `fluree-smoke` recipe at `Makefile:35` uses spaces instead of a tab), so targets were run directly. Worth a separate fix.

**Knock-on:** this closes the open review flag in IndependentImpact/ii-namespace#6 — the native-string consensus timestamp makes the `hed:HederaMessageId` → `hgo:TopicMessage` re-ranging a much closer match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
